### PR TITLE
Rename devices_control to devices_commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ from switchbot_client import SwitchBotAPIClient, ControlCommand
 
 client = SwitchBotAPIClient()
 device_id = "12345" # My Light(virtual infrared remote devices)
-print(client.devices_control(device_id, ControlCommand.VirtualInfrared.TURN_ON))
+print(client.devices_commands(device_id, ControlCommand.VirtualInfrared.TURN_ON))
 ```
 
 ```
@@ -200,7 +200,7 @@ def control_all_infrared_remotes_by_type(type: str, command: str):
     devices = filter(lambda d: d["remoteType"] == type, infrared_remotes)
 
     for d in devices:
-        client.devices_control(d["deviceId"], command)
+        client.devices_commands(d["deviceId"], command)
 
 
 def call_this_function_when_i_go_out():

--- a/switchbot_client/client.py
+++ b/switchbot_client/client.py
@@ -60,7 +60,7 @@ class SwitchBotAPIClient:
             )
         return formatted_response
 
-    def devices_control(
+    def devices_commands(
         self,
         device_id: str,
         command: str,

--- a/switchbot_client/devices.py
+++ b/switchbot_client/devices.py
@@ -38,7 +38,7 @@ class SwitchBotDevice:
     def control(
         self, command: str, parameter: str = None, command_type: str = None
     ) -> SwitchBotAPIResponse:
-        return self.client.devices_control(self.device_id, command, parameter, command_type)
+        return self.client.devices_commands(self.device_id, command, parameter, command_type)
 
 
 class Bot(SwitchBotDevice):

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -94,7 +94,7 @@ def test_light(monkeypatch):
             },
         )
 
-    def mock_devices_control(
+    def mock_devices_commands(
         self,
         device_id: str,
         command: str,
@@ -113,7 +113,7 @@ def test_light(monkeypatch):
         )
 
     monkeypatch.setattr(SwitchBotAPIClient, "devices", mock_devices)
-    monkeypatch.setattr(SwitchBotAPIClient, "devices_control", mock_devices_control)
+    monkeypatch.setattr(SwitchBotAPIClient, "devices_commands", mock_devices_commands)
 
     device = Light(client, "00-202001010000-12345678")
     result = device.turn_on()


### PR DESCRIPTION
Closes #9

- Make disruptive changes because it is assumed that the number of users is still low.