### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,24 @@
+0.2.0, 2021-10-30
+-------------------------
+
+- API Interface Change
+  - Use object interface as the main one
+  - It is recommended to use SwitchBotClient instead of SwitchBotAPIClient
+- Add new devices(Motion Sensor, Contact Sensor, Color Bulb, Remote)
+- Use `switchbot-client/{version}` as the user agent when requesting the SwitchBot API
+- Remove Python 3.6.x support and add Python 3.10.x support
+
 0.1.2, 2021-09-11
 -------------------------
 
 - Support ~/.config/switchbot-client config file
 - Add object interface for all devices
-- Add Python >=3.6.0 support
 - Rename devices_control to devices_commands
 
 0.1.1, 2021-09-05
 -------------------------
 
-- Add [object interface](https://github.com/kzosabe/switchbot-client#object-interface)
+- Add object interface
 
 0.1.0, 2021-09-04
 -------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "switchbot-client"
-version = "0.1.2"
+version = "0.2.0"
 description = "A Python client library for SwitchBot API."
 license = "Apache-2.0 or MIT"
 authors = [

--- a/switchbot_client/constants.py
+++ b/switchbot_client/constants.py
@@ -1,2 +1,2 @@
 class AppConstants:
-    VERSION = "0.1.2"
+    VERSION = "0.2.0"


### PR DESCRIPTION
- API Interface Change
  - Use object interface as the main one
  - It is recommended to use SwitchBotClient instead of SwitchBotAPIClient
- Add new devices(Motion Sensor, Contact Sensor, Color Bulb, Remote)
- Use `switchbot-client/{version}` as the user agent when requesting the SwitchBot API
- Remove Python 3.6.x support and add Python 3.10.x support