### PR TITLE
Release 0.2.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,4 +42,4 @@ jobs:
         run: poetry install --no-interaction --no-root
 
       - name: Run Tests
-        run: ./scripts/run_tests.sh
+        run: poetry run tox

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ __pycache__/
 *$py.class
 build/
 dist/
+/.tox
 .idea
 !.keep

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,24 @@
+0.2.0, 2021-10-30
+-------------------------
+
+- API Interface Change
+  - Use object interface as the main one
+  - It is recommended to use SwitchBotClient instead of SwitchBotAPIClient
+- Add new devices(Motion Sensor, Contact Sensor, Color Bulb, Remote)
+- Use `switchbot-client/{version}` as the user agent when requesting the SwitchBot API
+- Remove Python 3.6.x support and add Python 3.10.x support
+
 0.1.2, 2021-09-11
 -------------------------
 
 - Support ~/.config/switchbot-client config file
 - Add object interface for all devices
-- Add Python >=3.6.0 support
 - Rename devices_control to devices_commands
 
 0.1.1, 2021-09-05
 -------------------------
 
-- Add [object interface](https://github.com/kzosabe/switchbot-client#object-interface)
+- Add object interface
 
 0.1.0, 2021-09-04
 -------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 -------------------------
 
 - Add [object interface](https://github.com/kzosabe/switchbot-client#object-interface)
-- Add Python >=3.6.2 support
 
 0.1.0, 2021-09-04
 -------------------------

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ air_conditioner.set_all(
 ### Examples
 
 ```python
-from switchbot_client.enums import ControlCommand
+from switchbot_client.enums import ControlCommand, RemoteType
 from switchbot_client import SwitchBotAPIClient
 
 
@@ -206,10 +206,10 @@ def control_all_infrared_remotes_by_type(type: str, command: str):
 def call_this_function_when_i_go_out():
     print("turn off all lights and air conditioners...")
     control_all_infrared_remotes_by_type(
-        "Light", ControlCommand.VirtualInfrared.TURN_OFF
+        RemoteType.LIGHT, ControlCommand.VirtualInfrared.TURN_OFF
     )
     control_all_infrared_remotes_by_type(
-        "Air Conditioner", ControlCommand.VirtualInfrared.TURN_OFF
+        RemoteType.AIR_CONDITIONER, ControlCommand.VirtualInfrared.TURN_OFF
     )
     print("done")
 ```

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ print(result.body)
 ```
 
 ```
-{'deviceList': [{'deviceId': 'ABCDEFG', 'deviceName': 'Meter 0A', 'deviceType': 'Meter', 'enableCloudService': True, 'hubDeviceId': 'ABCDE'}, {'deviceId': 'ABCDE', 'deviceName': 'Hub Mini 0', 'deviceType': 'Hub Mini', 'hubDeviceId': 'ABCDE'}], 'infraredRemoteList': [{'deviceId': '12345', 'deviceName': 'My Light', 'remoteType': 'Light', 'hubDeviceId': 'ABCDE'}, {'deviceId': '12345, 'deviceName': 'My Air Conditioner', 'remoteType': 'Air Conditioner', 'hubDeviceId': 'ABCDE'}]}
+{'deviceList': [{'deviceId': 'ABCDEFG', 'deviceName': 'Meter 0A', 'deviceType': 'Meter', 'enableCloudService': True, 'hubDeviceId': 'ABCDE'}, {'deviceId': 'ABCDE', 'deviceName': 'Hub Mini 0', 'deviceType': 'Hub Mini', 'hubDeviceId': 'ABCDE'}], 'infraredRemoteList': [{'deviceId': '12345', 'deviceName': 'My Light', 'remoteType': 'Light', 'hubDeviceId': 'ABCDE'}, {'deviceId': '12345', 'deviceName': 'My Air Conditioner', 'remoteType': 'Air Conditioner', 'hubDeviceId': 'ABCDE'}]}
 ```
 
 If you run the above code, you will get a list of all the devices associated with your SwitchBot account. 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ python3 your_script.py
 
 ```python
 # your_script.py
-from switchbot_client import SwitchBotAPIClient
+from switchbot_client import SwitchBotClient
 
-client = SwitchBotAPIClient()
+client = SwitchBotClient()
 print(client.devices())
 ```
 
@@ -47,10 +47,10 @@ print(client.devices())
 It is also possible to initialize the client by passing a token directly as an argument.
 
 ```python
-from switchbot_client import SwitchBotAPIClient
+from switchbot_client import SwitchBotClient
 
 your_token = "your_switchbot_open_token"
-client = SwitchBotAPIClient(token=your_token)
+client = SwitchBotClient(token=your_token)
 print(client.devices())
 ```
 
@@ -67,9 +67,9 @@ python3 your_script.py
 
 ```python
 # your_script.py
-from switchbot_client import SwitchBotAPIClient
+from switchbot_client import SwitchBotClient
 
-client = SwitchBotAPIClient()
+client = SwitchBotClient()
 print(client.devices())
 ```
 
@@ -78,32 +78,32 @@ print(client.devices())
 ### Get Device List
 
 ```python
-from switchbot_client import SwitchBotAPIClient
+from switchbot_client import SwitchBotClient
 
-client = SwitchBotAPIClient()
+client = SwitchBotClient()
 result = client.devices()
-print(result.body)
+print(result)
 ```
 
 ```
-{'deviceList': [{'deviceId': 'ABCDEFG', 'deviceName': 'Meter 0A', 'deviceType': 'Meter', 'enableCloudService': True, 'hubDeviceId': 'ABCDE'}, {'deviceId': 'ABCDE', 'deviceName': 'Hub Mini 0', 'deviceType': 'Hub Mini', 'hubDeviceId': 'ABCDE'}], 'infraredRemoteList': [{'deviceId': '12345', 'deviceName': 'My Light', 'remoteType': 'Light', 'hubDeviceId': 'ABCDE'}, {'deviceId': '12345', 'deviceName': 'My Air Conditioner', 'remoteType': 'Air Conditioner', 'hubDeviceId': 'ABCDE'}]}
+[Meter({'device_id': 'ABCDEFG', 'device_type': 'Meter', 'device_name': 'Meter 0A', 'hub_device_id': 'ABCDE', 'is_virtual_infrared': False}), HubMini({'device_id': 'ABCDEFG', 'device_type': 'Hub Mini', 'device_name': 'Hub Mini 0', 'hub_device_id': None, 'is_virtual_infrared': False}), Light({'device_id': '12345', 'device_type': 'Light', 'device_name': 'My Light', 'hub_device_id': 'ABCDE', 'is_virtual_infrared': True}), AirConditioner({'device_id': '12345', 'device_type': 'Air Conditioner', 'device_name': 'My Air Conditioner', 'hub_device_id': 'ABCDE', 'is_virtual_infrared': True})]
 ```
 
 If you run the above code, you will get a list of all the devices associated with your SwitchBot account. 
-You can perform operations on the acquired `deviceId`, such as manipulating it or getting its status.
+You can perform operations on the acquired `device_id`, such as manipulating it or getting its status.
 
 ### Get Device Status
 
 ```python
-from switchbot_client import SwitchBotAPIClient
+from switchbot_client import SwitchBotClient
 
-client = SwitchBotAPIClient()
+client = SwitchBotClient()
 device_id = "YOUR_DEVICE_ID"
-print(client.devices_status(device_id))
+print(client.device(device_id).status())
 ```
 
 ```
-SwitchBotAPIResponse(status_code=100, message='success', body={'deviceId': 'ABCDE', 'deviceType': 'Meter', 'hubDeviceId': 'ABCDE', 'humidity': 50, 'temperature': 25.0})
+DeviceStatus(device_id='ABCDE', device_type='Meter', device_name='Meter 0', hub_device_id='ABCDE', data={'deviceId': 'ABCDE', 'deviceType': 'Meter', 'hubDeviceId': 'ABCDE', 'humidity': 50, 'temperature': 25.0})
 ```
 
 This function allows you to get the status of a device.
@@ -116,33 +116,35 @@ https://github.com/OpenWonderLabs/SwitchBotAPI#get-device-status
 ### Control Device
 
 ```python
-from switchbot_client import SwitchBotAPIClient, ControlCommand
+from switchbot_client import SwitchBotAPIClient
+from switchbot_client.devices import Light
 
 client = SwitchBotAPIClient()
-device_id = "12345" # My Light(virtual infrared remote devices)
-print(client.devices_commands(device_id, ControlCommand.VirtualInfrared.TURN_ON))
+device_id = "12345"  # My Light(virtual infrared remote devices)
+device = Light.create_by_id(client, device_id)
+print(device.turn_on())
 ```
 
 ```
-SwitchBotAPIResponse(status_code=100, message='success', body={})
+SwitchBotCommandResult(status_code=100, message='success', response_body={})
 ```
 
 It allows you to control the specified device.
-The `ControlCommand` class and the following documents define the commands that can be executed.
+The following documents define the commands that can be executed.
 
 https://github.com/OpenWonderLabs/SwitchBotAPI#send-device-control-commands
 
 ### Get Scene List
 
 ```python
-from switchbot_client import SwitchBotAPIClient
+from switchbot_client import SwitchBotClient
 
-client = SwitchBotAPIClient()
+client = SwitchBotClient()
 print(client.scenes())
 ```
 
 ```
-SwitchBotAPIResponse(status_code=100, message='success', body=[{'sceneId': '12345', 'sceneName': 'My Scene'}])
+[SwitchBotScene({'scene_id': '12345', 'scene_name': 'My Scene1'}), SwitchBotScene({'scene_id': '23456', 'scene_name': 'My Scene2'})]
 ```
 
 You can get a list of all the scenes associated with your SwitchBot account.
@@ -150,68 +152,83 @@ Note that only manual scenes are returned from this api.
 
 ### Execute Scene
 ```python
-from switchbot_client import SwitchBotAPIClient
+from switchbot_client import SwitchBotClient
 
-client = SwitchBotAPIClient()
-print(client.scenes_execute("12345"))
+client = SwitchBotClient()
+print(client.scene("12345").execute())
 ```
 
 ```
-SwitchBotAPIResponse(status_code=100, message='success', body={})
+SwitchBotCommandResult(status_code=100, message='success', response_body={})
 ```
 The specified scene can be executed immediately.
 
-### Object interface
+### Raw API interface
 
-Devices can be manipulated via an easy-to-use object wrapped API.
+Devices and scenes also can be manipulated via the low-level raw API client.
+The `SwitchBotAPIClient` class has methods for each endpoints of SwitchBot API.
 
-```python
-from switchbot_client import SwitchBotAPIClient
-from switchbot_client.devices import Light, AirConditioner
+For example the `/v1.0/devices` endpoint is implemented as `SwitchBotAPIClient.devices()`, 
+the `/v1.0/devices/{device_id}/status"` endpoint is implemented as `SwitchBotAPIClient.devices_status(device_id: str)`.
 
-client = SwitchBotAPIClient()
-
-# You can get your Lights and Air Conditioners device ids by
-# print(client.devices().body["infraredRemoteList"])
-
-light = Light(client, device_id="my_light_device_id")
-light.turn_on()
-
-air_conditioner = AirConditioner(client, device_id="my_air_conditioner_device_id")
-air_conditioner.set_all(
-    temperature=25,
-    mode=AirConditioner.Parameters.MODE_DRY,
-    fan_speed=AirConditioner.Parameters.FAN_SPEED_AUTO,
-    power=AirConditioner.Parameters.POWER_ON
-)
-```
 
 ### Examples
 
 ```python
-from switchbot_client.enums import ControlCommand, RemoteType
-from switchbot_client import SwitchBotAPIClient
-
-
-def control_all_infrared_remotes_by_type(type: str, command: str):
-    client = SwitchBotAPIClient()
-    devices = client.devices()
-    infrared_remotes = devices.body["infraredRemoteList"]
-    devices = filter(lambda d: d["remoteType"] == type, infrared_remotes)
-
-    for d in devices:
-        client.devices_commands(d["deviceId"], command)
+from switchbot_client import devices
+from switchbot_client import SwitchBotClient
 
 
 def call_this_function_when_i_go_out():
+    client = SwitchBotClient()
     print("turn off all lights and air conditioners...")
-    control_all_infrared_remotes_by_type(
-        RemoteType.LIGHT, ControlCommand.VirtualInfrared.TURN_OFF
-    )
-    control_all_infrared_remotes_by_type(
-        RemoteType.AIR_CONDITIONER, ControlCommand.VirtualInfrared.TURN_OFF
-    )
+    for d in client.devices():
+        if isinstance(d, devices.Light):
+            d.turn_off()
+
+        if isinstance(d, devices.ColorBulb):
+            d.turn_off()
+
+        if isinstance(d, devices.AirConditioner):
+            d.turn_off()
     print("done")
+
+
+def control_devices_by_temperature():
+    client = SwitchBotClient()
+    all_devices = client.devices()
+
+    temperatures = [d.temperature() for d in all_devices if isinstance(d, devices.Meter)]
+    temperature = min(temperatures)
+
+    color_bulbs = [d for d in all_devices if isinstance(d, devices.ColorBulb)]
+    air_conditioners = [d for d in all_devices if isinstance(d, devices.AirConditioner)]
+
+    if temperature > 25.0:
+        print("hot!")
+        for d in color_bulbs:
+            d.set_color("#FF0000")
+
+        for d in air_conditioners:
+            d.set_all(
+                temperature=20.0,
+                mode=devices.AirConditioner.Parameters.MODE_COOL,
+                fan_speed=devices.AirConditioner.Parameters.FAN_SPEED_HIGH,
+                power=devices.AirConditioner.Parameters.POWER_ON
+            )
+
+    elif temperature < 15.0:
+        print("cold!")
+        for d in color_bulbs:
+            d.set_color("#0000FF")
+
+        for d in air_conditioners:
+            d.set_all(
+                temperature=20.0,
+                mode=devices.AirConditioner.Parameters.MODE_HEAT,
+                fan_speed=devices.AirConditioner.Parameters.FAN_SPEED_HIGH,
+                power=devices.AirConditioner.Parameters.POWER_ON
+            )
 ```
 
 ## License

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,14 +1,6 @@
 [[package]]
-name = "appdirs"
-version = "1.4.4"
-description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-category = "dev"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "astroid"
-version = "2.7.3"
+version = "2.8.4"
 description = "An abstract syntax tree for Python with inference support."
 category = "dev"
 optional = false
@@ -17,8 +9,8 @@ python-versions = "~=3.6"
 [package.dependencies]
 lazy-object-proxy = ">=1.4.0"
 typed-ast = {version = ">=1.4.0,<1.5", markers = "implementation_name == \"cpython\" and python_version < \"3.8\""}
-typing-extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
-wrapt = ">=1.11,<1.13"
+typing-extensions = {version = ">=3.10", markers = "python_version < \"3.10\""}
+wrapt = ">=1.11,<1.14"
 
 [[package]]
 name = "atomicwrites"
@@ -59,29 +51,35 @@ testing = ["pytest (>=4.6)", "pytest-flake8", "pytest-cov", "pytest-black (>=0.3
 
 [[package]]
 name = "black"
-version = "20.8b1"
+version = "21.9b0"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.6.2"
 
 [package.dependencies]
-appdirs = "*"
 click = ">=7.1.2"
 mypy-extensions = ">=0.4.3"
-pathspec = ">=0.6,<1"
+pathspec = ">=0.9.0,<1"
+platformdirs = ">=2"
 regex = ">=2020.1.8"
-toml = ">=0.10.1"
-typed-ast = ">=1.4.0"
-typing-extensions = ">=3.7.4"
+tomli = ">=0.2.6,<2.0.0"
+typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\""}
+typing-extensions = [
+    {version = ">=3.10.0.0", markers = "python_version < \"3.10\""},
+    {version = "!=3.10.0.1", markers = "python_version >= \"3.10\""},
+]
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
+d = ["aiohttp (>=3.6.0)", "aiohttp-cors (>=0.4.0)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+python2 = ["typed-ast (>=1.4.2)"]
+uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "certifi"
-version = "2021.5.30"
+version = "2021.10.8"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
@@ -89,7 +87,7 @@ python-versions = "*"
 
 [[package]]
 name = "charset-normalizer"
-version = "2.0.4"
+version = "2.0.7"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
 optional = false
@@ -100,7 +98,7 @@ unicode_backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
-version = "8.0.1"
+version = "8.0.3"
 description = "Composable command line interface toolkit"
 category = "dev"
 optional = false
@@ -120,18 +118,18 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "coverage"
-version = "5.5"
+version = "6.0.2"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+python-versions = ">=3.6"
 
 [package.extras]
-toml = ["toml"]
+toml = ["tomli"]
 
 [[package]]
 name = "distlib"
-version = "0.3.2"
+version = "0.3.3"
 description = "Distribution utilities"
 category = "dev"
 optional = false
@@ -139,29 +137,33 @@ python-versions = "*"
 
 [[package]]
 name = "filelock"
-version = "3.0.12"
+version = "3.3.2"
 description = "A platform independent file lock."
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
+
+[package.extras]
+docs = ["furo (>=2021.8.17b43)", "sphinx (>=4.1)", "sphinx-autodoc-typehints (>=1.12)"]
+testing = ["covdefaults (>=1.2.0)", "coverage (>=4)", "pytest (>=4)", "pytest-cov", "pytest-timeout (>=1.4.2)"]
 
 [[package]]
 name = "flake8"
-version = "3.9.2"
+version = "4.0.1"
 description = "the modular source code checker: pep8 pyflakes and co"
 category = "dev"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+python-versions = ">=3.6"
 
 [package.dependencies]
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+importlib-metadata = {version = "<4.3", markers = "python_version < \"3.8\""}
 mccabe = ">=0.6.0,<0.7.0"
-pycodestyle = ">=2.7.0,<2.8.0"
-pyflakes = ">=2.3.0,<2.4.0"
+pycodestyle = ">=2.8.0,<2.9.0"
+pyflakes = ">=2.4.0,<2.5.0"
 
 [[package]]
 name = "idna"
-version = "3.2"
+version = "3.3"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
 optional = false
@@ -169,7 +171,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.8.1"
+version = "4.2.0"
 description = "Read metadata from Python packages"
 category = "dev"
 optional = false
@@ -181,8 +183,7 @@ zipp = ">=0.5"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-perf = ["ipython"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "iniconfig"
@@ -196,7 +197,7 @@ python-versions = "*"
 name = "isort"
 version = "5.9.3"
 description = "A Python utility / library to sort Python imports."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6.1,<4.0"
 
@@ -250,14 +251,14 @@ python-versions = "*"
 
 [[package]]
 name = "packaging"
-version = "21.0"
+version = "21.2"
 description = "Core utilities for Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyparsing = ">=2.0.2"
+pyparsing = ">=2.0.2,<3"
 
 [[package]]
 name = "pathspec"
@@ -269,7 +270,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [[package]]
 name = "platformdirs"
-version = "2.3.0"
+version = "2.4.0"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
@@ -304,15 +305,15 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pycodestyle"
-version = "2.7.0"
+version = "2.8.0"
 description = "Python style guide checker"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pyflakes"
-version = "2.3.1"
+version = "2.4.0"
 description = "passive checker of Python programs"
 category = "dev"
 optional = false
@@ -320,19 +321,20 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pylint"
-version = "2.10.2"
+version = "2.11.1"
 description = "python code static checker"
 category = "dev"
 optional = false
 python-versions = "~=3.6"
 
 [package.dependencies]
-astroid = ">=2.7.2,<2.8"
+astroid = ">=2.8.0,<2.9"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 isort = ">=4.2.5,<6"
 mccabe = ">=0.6,<0.7"
 platformdirs = ">=2.2.0"
 toml = ">=0.7.1"
+typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""}
 
 [[package]]
 name = "pyparsing"
@@ -404,7 +406,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [[package]]
 name = "regex"
-version = "2021.8.28"
+version = "2021.10.23"
 description = "Alternative regular expression module, to replace re."
 category = "dev"
 optional = false
@@ -445,8 +447,16 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "tomli"
+version = "1.2.2"
+description = "A lil' TOML parser"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "tox"
-version = "3.24.3"
+version = "3.24.4"
 description = "tox is a generic virtualenv management and test command line tool"
 category = "dev"
 optional = false
@@ -485,7 +495,7 @@ python-versions = "*"
 
 [[package]]
 name = "urllib3"
-version = "1.26.6"
+version = "1.26.7"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
@@ -498,7 +508,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.7.2"
+version = "20.9.0"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -507,7 +517,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [package.dependencies]
 "backports.entry-points-selectable" = ">=1.0.4"
 distlib = ">=0.3.1,<1"
-filelock = ">=3.0.0,<4"
+filelock = ">=3.2,<4"
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 platformdirs = ">=2,<3"
 six = ">=1.9.0,<2"
@@ -518,15 +528,15 @@ testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", 
 
 [[package]]
 name = "wrapt"
-version = "1.12.1"
+version = "1.13.3"
 description = "Module for decorators, wrappers and monkey patching."
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [[package]]
 name = "zipp"
-version = "3.5.0"
+version = "3.6.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "dev"
 optional = false
@@ -539,16 +549,12 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "f826accd174a99a2ea3994ec547c2f425c1e730f30c998b70146e706f65cb23f"
+content-hash = "bf7852dfb0c239d65dd5c9aeed1f381440e900b478ec3b2f1d8069b4945a6cc5"
 
 [metadata.files]
-appdirs = [
-    {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
-    {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
-]
 astroid = [
-    {file = "astroid-2.7.3-py3-none-any.whl", hash = "sha256:dc1e8b28427d6bbef6b8842b18765ab58f558c42bb80540bd7648c98412af25e"},
-    {file = "astroid-2.7.3.tar.gz", hash = "sha256:3b680ce0419b8a771aba6190139a3998d14b413852506d99aff8dc2bf65ee67c"},
+    {file = "astroid-2.8.4-py3-none-any.whl", hash = "sha256:0755c998e7117078dcb7d0bda621391dd2a85da48052d948c7411ab187325346"},
+    {file = "astroid-2.8.4.tar.gz", hash = "sha256:1e83a69fd51b013ebf5912d26b9338d6643a55fec2f20c787792680610eed4a2"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
@@ -563,97 +569,79 @@ attrs = [
     {file = "backports.entry_points_selectable-1.1.0.tar.gz", hash = "sha256:988468260ec1c196dab6ae1149260e2f5472c9110334e5d51adcb77867361f6a"},
 ]
 black = [
-    {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
+    {file = "black-21.9b0-py3-none-any.whl", hash = "sha256:380f1b5da05e5a1429225676655dddb96f5ae8c75bdf91e53d798871b902a115"},
+    {file = "black-21.9b0.tar.gz", hash = "sha256:7de4cfc7eb6b710de325712d40125689101d21d25283eed7e9998722cf10eb91"},
 ]
 certifi = [
-    {file = "certifi-2021.5.30-py2.py3-none-any.whl", hash = "sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"},
-    {file = "certifi-2021.5.30.tar.gz", hash = "sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee"},
+    {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
+    {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
 ]
 charset-normalizer = [
-    {file = "charset-normalizer-2.0.4.tar.gz", hash = "sha256:f23667ebe1084be45f6ae0538e4a5a865206544097e4e8bbcacf42cd02a348f3"},
-    {file = "charset_normalizer-2.0.4-py3-none-any.whl", hash = "sha256:0c8911edd15d19223366a194a513099a302055a962bca2cec0f54b8b63175d8b"},
+    {file = "charset-normalizer-2.0.7.tar.gz", hash = "sha256:e019de665e2bcf9c2b64e2e5aa025fa991da8720daa3c1138cadd2fd1856aed0"},
+    {file = "charset_normalizer-2.0.7-py3-none-any.whl", hash = "sha256:f7af805c321bfa1ce6714c51f254e0d5bb5e5834039bc17db7ebe3a4cec9492b"},
 ]
 click = [
-    {file = "click-8.0.1-py3-none-any.whl", hash = "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"},
-    {file = "click-8.0.1.tar.gz", hash = "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a"},
+    {file = "click-8.0.3-py3-none-any.whl", hash = "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3"},
+    {file = "click-8.0.3.tar.gz", hash = "sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b"},
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 coverage = [
-    {file = "coverage-5.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf"},
-    {file = "coverage-5.5-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:b7895207b4c843c76a25ab8c1e866261bcfe27bfaa20c192de5190121770672b"},
-    {file = "coverage-5.5-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:c2723d347ab06e7ddad1a58b2a821218239249a9e4365eaff6649d31180c1669"},
-    {file = "coverage-5.5-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:900fbf7759501bc7807fd6638c947d7a831fc9fdf742dc10f02956ff7220fa90"},
-    {file = "coverage-5.5-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:004d1880bed2d97151facef49f08e255a20ceb6f9432df75f4eef018fdd5a78c"},
-    {file = "coverage-5.5-cp27-cp27m-win32.whl", hash = "sha256:06191eb60f8d8a5bc046f3799f8a07a2d7aefb9504b0209aff0b47298333302a"},
-    {file = "coverage-5.5-cp27-cp27m-win_amd64.whl", hash = "sha256:7501140f755b725495941b43347ba8a2777407fc7f250d4f5a7d2a1050ba8e82"},
-    {file = "coverage-5.5-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:372da284cfd642d8e08ef606917846fa2ee350f64994bebfbd3afb0040436905"},
-    {file = "coverage-5.5-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:8963a499849a1fc54b35b1c9f162f4108017b2e6db2c46c1bed93a72262ed083"},
-    {file = "coverage-5.5-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:869a64f53488f40fa5b5b9dcb9e9b2962a66a87dab37790f3fcfb5144b996ef5"},
-    {file = "coverage-5.5-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:4a7697d8cb0f27399b0e393c0b90f0f1e40c82023ea4d45d22bce7032a5d7b81"},
-    {file = "coverage-5.5-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:8d0a0725ad7c1a0bcd8d1b437e191107d457e2ec1084b9f190630a4fb1af78e6"},
-    {file = "coverage-5.5-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:51cb9476a3987c8967ebab3f0fe144819781fca264f57f89760037a2ea191cb0"},
-    {file = "coverage-5.5-cp310-cp310-win_amd64.whl", hash = "sha256:c0891a6a97b09c1f3e073a890514d5012eb256845c451bd48f7968ef939bf4ae"},
-    {file = "coverage-5.5-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:3487286bc29a5aa4b93a072e9592f22254291ce96a9fbc5251f566b6b7343cdb"},
-    {file = "coverage-5.5-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:deee1077aae10d8fa88cb02c845cfba9b62c55e1183f52f6ae6a2df6a2187160"},
-    {file = "coverage-5.5-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6"},
-    {file = "coverage-5.5-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:6c90e11318f0d3c436a42409f2749ee1a115cd8b067d7f14c148f1ce5574d701"},
-    {file = "coverage-5.5-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:30c77c1dc9f253283e34c27935fded5015f7d1abe83bc7821680ac444eaf7793"},
-    {file = "coverage-5.5-cp35-cp35m-win32.whl", hash = "sha256:9a1ef3b66e38ef8618ce5fdc7bea3d9f45f3624e2a66295eea5e57966c85909e"},
-    {file = "coverage-5.5-cp35-cp35m-win_amd64.whl", hash = "sha256:972c85d205b51e30e59525694670de6a8a89691186012535f9d7dbaa230e42c3"},
-    {file = "coverage-5.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:af0e781009aaf59e25c5a678122391cb0f345ac0ec272c7961dc5455e1c40066"},
-    {file = "coverage-5.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:74d881fc777ebb11c63736622b60cb9e4aee5cace591ce274fb69e582a12a61a"},
-    {file = "coverage-5.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:92b017ce34b68a7d67bd6d117e6d443a9bf63a2ecf8567bb3d8c6c7bc5014465"},
-    {file = "coverage-5.5-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:d636598c8305e1f90b439dbf4f66437de4a5e3c31fdf47ad29542478c8508bbb"},
-    {file = "coverage-5.5-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:41179b8a845742d1eb60449bdb2992196e211341818565abded11cfa90efb821"},
-    {file = "coverage-5.5-cp36-cp36m-win32.whl", hash = "sha256:040af6c32813fa3eae5305d53f18875bedd079960822ef8ec067a66dd8afcd45"},
-    {file = "coverage-5.5-cp36-cp36m-win_amd64.whl", hash = "sha256:5fec2d43a2cc6965edc0bb9e83e1e4b557f76f843a77a2496cbe719583ce8184"},
-    {file = "coverage-5.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:18ba8bbede96a2c3dde7b868de9dcbd55670690af0988713f0603f037848418a"},
-    {file = "coverage-5.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:2910f4d36a6a9b4214bb7038d537f015346f413a975d57ca6b43bf23d6563b53"},
-    {file = "coverage-5.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:f0b278ce10936db1a37e6954e15a3730bea96a0997c26d7fee88e6c396c2086d"},
-    {file = "coverage-5.5-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:796c9c3c79747146ebd278dbe1e5c5c05dd6b10cc3bcb8389dfdf844f3ead638"},
-    {file = "coverage-5.5-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:53194af30d5bad77fcba80e23a1441c71abfb3e01192034f8246e0d8f99528f3"},
-    {file = "coverage-5.5-cp37-cp37m-win32.whl", hash = "sha256:184a47bbe0aa6400ed2d41d8e9ed868b8205046518c52464fde713ea06e3a74a"},
-    {file = "coverage-5.5-cp37-cp37m-win_amd64.whl", hash = "sha256:2949cad1c5208b8298d5686d5a85b66aae46d73eec2c3e08c817dd3513e5848a"},
-    {file = "coverage-5.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:217658ec7187497e3f3ebd901afdca1af062b42cfe3e0dafea4cced3983739f6"},
-    {file = "coverage-5.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1aa846f56c3d49205c952d8318e76ccc2ae23303351d9270ab220004c580cfe2"},
-    {file = "coverage-5.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:24d4a7de75446be83244eabbff746d66b9240ae020ced65d060815fac3423759"},
-    {file = "coverage-5.5-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:d1f8bf7b90ba55699b3a5e44930e93ff0189aa27186e96071fac7dd0d06a1873"},
-    {file = "coverage-5.5-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:970284a88b99673ccb2e4e334cfb38a10aab7cd44f7457564d11898a74b62d0a"},
-    {file = "coverage-5.5-cp38-cp38-win32.whl", hash = "sha256:01d84219b5cdbfc8122223b39a954820929497a1cb1422824bb86b07b74594b6"},
-    {file = "coverage-5.5-cp38-cp38-win_amd64.whl", hash = "sha256:2e0d881ad471768bf6e6c2bf905d183543f10098e3b3640fc029509530091502"},
-    {file = "coverage-5.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d1f9ce122f83b2305592c11d64f181b87153fc2c2bbd3bb4a3dde8303cfb1a6b"},
-    {file = "coverage-5.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:13c4ee887eca0f4c5a247b75398d4114c37882658300e153113dafb1d76de529"},
-    {file = "coverage-5.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:52596d3d0e8bdf3af43db3e9ba8dcdaac724ba7b5ca3f6358529d56f7a166f8b"},
-    {file = "coverage-5.5-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:2cafbbb3af0733db200c9b5f798d18953b1a304d3f86a938367de1567f4b5bff"},
-    {file = "coverage-5.5-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:44d654437b8ddd9eee7d1eaee28b7219bec228520ff809af170488fd2fed3e2b"},
-    {file = "coverage-5.5-cp39-cp39-win32.whl", hash = "sha256:d314ed732c25d29775e84a960c3c60808b682c08d86602ec2c3008e1202e3bb6"},
-    {file = "coverage-5.5-cp39-cp39-win_amd64.whl", hash = "sha256:13034c4409db851670bc9acd836243aeee299949bd5673e11844befcb0149f03"},
-    {file = "coverage-5.5-pp36-none-any.whl", hash = "sha256:f030f8873312a16414c0d8e1a1ddff2d3235655a2174e3648b4fa66b3f2f1079"},
-    {file = "coverage-5.5-pp37-none-any.whl", hash = "sha256:2a3859cb82dcbda1cfd3e6f71c27081d18aa251d20a17d87d26d4cd216fb0af4"},
-    {file = "coverage-5.5.tar.gz", hash = "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c"},
+    {file = "coverage-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1549e1d08ce38259de2bc3e9a0d5f3642ff4a8f500ffc1b2df73fd621a6cdfc0"},
+    {file = "coverage-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcae10fccb27ca2a5f456bf64d84110a5a74144be3136a5e598f9d9fb48c0caa"},
+    {file = "coverage-6.0.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:53a294dc53cfb39c74758edaa6305193fb4258a30b1f6af24b360a6c8bd0ffa7"},
+    {file = "coverage-6.0.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8251b37be1f2cd9c0e5ccd9ae0380909c24d2a5ed2162a41fcdbafaf59a85ebd"},
+    {file = "coverage-6.0.2-cp310-cp310-win32.whl", hash = "sha256:db42baa892cba723326284490283a68d4de516bfb5aaba369b4e3b2787a778b7"},
+    {file = "coverage-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:bbffde2a68398682623d9dd8c0ca3f46fda074709b26fcf08ae7a4c431a6ab2d"},
+    {file = "coverage-6.0.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:60e51a3dd55540bec686d7fff61b05048ca31e804c1f32cbb44533e6372d9cc3"},
+    {file = "coverage-6.0.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6a6a9409223a27d5ef3cca57dd7cd4dfcb64aadf2fad5c3b787830ac9223e01a"},
+    {file = "coverage-6.0.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:4b34ae4f51bbfa5f96b758b55a163d502be3dcb24f505d0227858c2b3f94f5b9"},
+    {file = "coverage-6.0.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3bbda1b550e70fa6ac40533d3f23acd4f4e9cb4e6e77251ce77fdf41b3309fb2"},
+    {file = "coverage-6.0.2-cp36-cp36m-win32.whl", hash = "sha256:4e28d2a195c533b58fc94a12826f4431726d8eb029ac21d874345f943530c122"},
+    {file = "coverage-6.0.2-cp36-cp36m-win_amd64.whl", hash = "sha256:a82d79586a0a4f5fd1cf153e647464ced402938fbccb3ffc358c7babd4da1dd9"},
+    {file = "coverage-6.0.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3be1206dc09fb6298de3fce70593e27436862331a85daee36270b6d0e1c251c4"},
+    {file = "coverage-6.0.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c9cd3828bbe1a40070c11fe16a51df733fd2f0cb0d745fb83b7b5c1f05967df7"},
+    {file = "coverage-6.0.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:d036dc1ed8e1388e995833c62325df3f996675779541f682677efc6af71e96cc"},
+    {file = "coverage-6.0.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:04560539c19ec26995ecfb3d9307ff154fbb9a172cb57e3b3cfc4ced673103d1"},
+    {file = "coverage-6.0.2-cp37-cp37m-win32.whl", hash = "sha256:e4fb7ced4d9dec77d6cf533acfbf8e1415fe799430366affb18d69ee8a3c6330"},
+    {file = "coverage-6.0.2-cp37-cp37m-win_amd64.whl", hash = "sha256:77b1da5767ed2f44611bc9bc019bc93c03fa495728ec389759b6e9e5039ac6b1"},
+    {file = "coverage-6.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:61b598cbdbaae22d9e34e3f675997194342f866bb1d781da5d0be54783dce1ff"},
+    {file = "coverage-6.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:36e9040a43d2017f2787b28d365a4bb33fcd792c7ff46a047a04094dc0e2a30d"},
+    {file = "coverage-6.0.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:9f1627e162e3864a596486774876415a7410021f4b67fd2d9efdf93ade681afc"},
+    {file = "coverage-6.0.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e7a0b42db2a47ecb488cde14e0f6c7679a2c5a9f44814393b162ff6397fcdfbb"},
+    {file = "coverage-6.0.2-cp38-cp38-win32.whl", hash = "sha256:a1b73c7c4d2a42b9d37dd43199c5711d91424ff3c6c22681bc132db4a4afec6f"},
+    {file = "coverage-6.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:1db67c497688fd4ba85b373b37cc52c50d437fd7267520ecd77bddbd89ea22c9"},
+    {file = "coverage-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f2f184bf38e74f152eed7f87e345b51f3ab0b703842f447c22efe35e59942c24"},
+    {file = "coverage-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cd1cf1deb3d5544bd942356364a2fdc8959bad2b6cf6eb17f47d301ea34ae822"},
+    {file = "coverage-6.0.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ad9b8c1206ae41d46ec7380b78ba735ebb77758a650643e841dd3894966c31d0"},
+    {file = "coverage-6.0.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:381d773d896cc7f8ba4ff3b92dee4ed740fb88dfe33b6e42efc5e8ab6dfa1cfe"},
+    {file = "coverage-6.0.2-cp39-cp39-win32.whl", hash = "sha256:424c44f65e8be58b54e2b0bd1515e434b940679624b1b72726147cfc6a9fc7ce"},
+    {file = "coverage-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:abbff240f77347d17306d3201e14431519bf64495648ca5a49571f988f88dee9"},
+    {file = "coverage-6.0.2-pp36-none-any.whl", hash = "sha256:7092eab374346121805fb637572483270324407bf150c30a3b161fc0c4ca5164"},
+    {file = "coverage-6.0.2-pp37-none-any.whl", hash = "sha256:30922626ce6f7a5a30bdba984ad21021529d3d05a68b4f71ea3b16bda35b8895"},
+    {file = "coverage-6.0.2.tar.gz", hash = "sha256:6807947a09510dc31fa86f43595bf3a14017cd60bf633cc746d52141bfa6b149"},
 ]
 distlib = [
-    {file = "distlib-0.3.2-py2.py3-none-any.whl", hash = "sha256:23e223426b28491b1ced97dc3bbe183027419dfc7982b4fa2f05d5f3ff10711c"},
-    {file = "distlib-0.3.2.zip", hash = "sha256:106fef6dc37dd8c0e2c0a60d3fca3e77460a48907f335fa28420463a6f799736"},
+    {file = "distlib-0.3.3-py2.py3-none-any.whl", hash = "sha256:c8b54e8454e5bf6237cc84c20e8264c3e991e824ef27e8f1e81049867d861e31"},
+    {file = "distlib-0.3.3.zip", hash = "sha256:d982d0751ff6eaaab5e2ec8e691d949ee80eddf01a62eaa96ddb11531fe16b05"},
 ]
 filelock = [
-    {file = "filelock-3.0.12-py3-none-any.whl", hash = "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"},
-    {file = "filelock-3.0.12.tar.gz", hash = "sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59"},
+    {file = "filelock-3.3.2-py3-none-any.whl", hash = "sha256:bb2a1c717df74c48a2d00ed625e5a66f8572a3a30baacb7657add1d7bac4097b"},
+    {file = "filelock-3.3.2.tar.gz", hash = "sha256:7afc856f74fa7006a289fd10fa840e1eebd8bbff6bffb69c26c54a0512ea8cf8"},
 ]
 flake8 = [
-    {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
-    {file = "flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b"},
+    {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
+    {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
 ]
 idna = [
-    {file = "idna-3.2-py3-none-any.whl", hash = "sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a"},
-    {file = "idna-3.2.tar.gz", hash = "sha256:467fbad99067910785144ce333826c71fb0e63a425657295239737f7ecd125f3"},
+    {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
+    {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.8.1-py3-none-any.whl", hash = "sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15"},
-    {file = "importlib_metadata-4.8.1.tar.gz", hash = "sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1"},
+    {file = "importlib_metadata-4.2.0-py3-none-any.whl", hash = "sha256:057e92c15bc8d9e8109738a48db0ccb31b4d9d5cfbee5a8670879a30be66304b"},
+    {file = "importlib_metadata-4.2.0.tar.gz", hash = "sha256:b7e52a1f8dec14a75ea73e0891f3060099ca1d8e6a462a4dff11c3e119ea1b31"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -721,16 +709,16 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
 packaging = [
-    {file = "packaging-21.0-py3-none-any.whl", hash = "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"},
-    {file = "packaging-21.0.tar.gz", hash = "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7"},
+    {file = "packaging-21.2-py3-none-any.whl", hash = "sha256:14317396d1e8cdb122989b916fa2c7e9ca8e2be9e8060a6eff75b6b7b4d8a7e0"},
+    {file = "packaging-21.2.tar.gz", hash = "sha256:096d689d78ca690e4cd8a89568ba06d07ca097e3306a4381635073ca91479966"},
 ]
 pathspec = [
     {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
     {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
 ]
 platformdirs = [
-    {file = "platformdirs-2.3.0-py3-none-any.whl", hash = "sha256:8003ac87717ae2c7ee1ea5a84a1a61e87f3fbd16eb5aadba194ea30a9019f648"},
-    {file = "platformdirs-2.3.0.tar.gz", hash = "sha256:15b056538719b1c94bdaccb29e5f81879c7f7f0f4a153f46086d155dffcd4f0f"},
+    {file = "platformdirs-2.4.0-py3-none-any.whl", hash = "sha256:8868bbe3c3c80d42f20156f22e7131d2fb321f5bc86a2a345375c6481a67021d"},
+    {file = "platformdirs-2.4.0.tar.gz", hash = "sha256:367a5e80b3d04d2428ffa76d33f124cf11e8fff2acdaa9b43d545f5c7d661ef2"},
 ]
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
@@ -741,16 +729,16 @@ py = [
     {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
 ]
 pycodestyle = [
-    {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},
-    {file = "pycodestyle-2.7.0.tar.gz", hash = "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"},
+    {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
+    {file = "pycodestyle-2.8.0.tar.gz", hash = "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"},
 ]
 pyflakes = [
-    {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},
-    {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
+    {file = "pyflakes-2.4.0-py2.py3-none-any.whl", hash = "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"},
+    {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
 ]
 pylint = [
-    {file = "pylint-2.10.2-py3-none-any.whl", hash = "sha256:e178e96b6ba171f8ef51fbce9ca30931e6acbea4a155074d80cc081596c9e852"},
-    {file = "pylint-2.10.2.tar.gz", hash = "sha256:6758cce3ddbab60c52b57dcc07f0c5d779e5daf0cf50f6faacbef1d3ea62d2a1"},
+    {file = "pylint-2.11.1-py3-none-any.whl", hash = "sha256:0f358e221c45cbd4dad2a1e4b883e75d28acdcccd29d40c76eb72b307269b126"},
+    {file = "pylint-2.11.1.tar.gz", hash = "sha256:2c9843fff1a88ca0ad98a256806c82c5a8f86086e7ccbdb93297d86c3f90c436"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
@@ -800,47 +788,42 @@ pyyaml = [
     {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
 ]
 regex = [
-    {file = "regex-2021.8.28-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9d05ad5367c90814099000442b2125535e9d77581855b9bee8780f1b41f2b1a2"},
-    {file = "regex-2021.8.28-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3bf1bc02bc421047bfec3343729c4bbbea42605bcfd6d6bfe2c07ade8b12d2a"},
-    {file = "regex-2021.8.28-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f6a808044faae658f546dd5f525e921de9fa409de7a5570865467f03a626fc0"},
-    {file = "regex-2021.8.28-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a617593aeacc7a691cc4af4a4410031654f2909053bd8c8e7db837f179a630eb"},
-    {file = "regex-2021.8.28-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:79aef6b5cd41feff359acaf98e040844613ff5298d0d19c455b3d9ae0bc8c35a"},
-    {file = "regex-2021.8.28-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0fc1f8f06977c2d4f5e3d3f0d4a08089be783973fc6b6e278bde01f0544ff308"},
-    {file = "regex-2021.8.28-cp310-cp310-win32.whl", hash = "sha256:6eebf512aa90751d5ef6a7c2ac9d60113f32e86e5687326a50d7686e309f66ed"},
-    {file = "regex-2021.8.28-cp310-cp310-win_amd64.whl", hash = "sha256:ac88856a8cbccfc14f1b2d0b829af354cc1743cb375e7f04251ae73b2af6adf8"},
-    {file = "regex-2021.8.28-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c206587c83e795d417ed3adc8453a791f6d36b67c81416676cad053b4104152c"},
-    {file = "regex-2021.8.28-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8690ed94481f219a7a967c118abaf71ccc440f69acd583cab721b90eeedb77c"},
-    {file = "regex-2021.8.28-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:328a1fad67445550b982caa2a2a850da5989fd6595e858f02d04636e7f8b0b13"},
-    {file = "regex-2021.8.28-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c7cb4c512d2d3b0870e00fbbac2f291d4b4bf2634d59a31176a87afe2777c6f0"},
-    {file = "regex-2021.8.28-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66256b6391c057305e5ae9209941ef63c33a476b73772ca967d4a2df70520ec1"},
-    {file = "regex-2021.8.28-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8e44769068d33e0ea6ccdf4b84d80c5afffe5207aa4d1881a629cf0ef3ec398f"},
-    {file = "regex-2021.8.28-cp36-cp36m-win32.whl", hash = "sha256:08d74bfaa4c7731b8dac0a992c63673a2782758f7cfad34cf9c1b9184f911354"},
-    {file = "regex-2021.8.28-cp36-cp36m-win_amd64.whl", hash = "sha256:abb48494d88e8a82601af905143e0de838c776c1241d92021e9256d5515b3645"},
-    {file = "regex-2021.8.28-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b4c220a1fe0d2c622493b0a1fd48f8f991998fb447d3cd368033a4b86cf1127a"},
-    {file = "regex-2021.8.28-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4a332404baa6665b54e5d283b4262f41f2103c255897084ec8f5487ce7b9e8e"},
-    {file = "regex-2021.8.28-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c61dcc1cf9fd165127a2853e2c31eb4fb961a4f26b394ac9fe5669c7a6592892"},
-    {file = "regex-2021.8.28-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ee329d0387b5b41a5dddbb6243a21cb7896587a651bebb957e2d2bb8b63c0791"},
-    {file = "regex-2021.8.28-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f60667673ff9c249709160529ab39667d1ae9fd38634e006bec95611f632e759"},
-    {file = "regex-2021.8.28-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b844fb09bd9936ed158ff9df0ab601e2045b316b17aa8b931857365ea8586906"},
-    {file = "regex-2021.8.28-cp37-cp37m-win32.whl", hash = "sha256:4cde065ab33bcaab774d84096fae266d9301d1a2f5519d7bd58fc55274afbf7a"},
-    {file = "regex-2021.8.28-cp37-cp37m-win_amd64.whl", hash = "sha256:1413b5022ed6ac0d504ba425ef02549a57d0f4276de58e3ab7e82437892704fc"},
-    {file = "regex-2021.8.28-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ed4b50355b066796dacdd1cf538f2ce57275d001838f9b132fab80b75e8c84dd"},
-    {file = "regex-2021.8.28-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28fc475f560d8f67cc8767b94db4c9440210f6958495aeae70fac8faec631797"},
-    {file = "regex-2021.8.28-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdc178caebd0f338d57ae445ef8e9b737ddf8fbc3ea187603f65aec5b041248f"},
-    {file = "regex-2021.8.28-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:999ad08220467b6ad4bd3dd34e65329dd5d0df9b31e47106105e407954965256"},
-    {file = "regex-2021.8.28-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:808ee5834e06f57978da3e003ad9d6292de69d2bf6263662a1a8ae30788e080b"},
-    {file = "regex-2021.8.28-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d5111d4c843d80202e62b4fdbb4920db1dcee4f9366d6b03294f45ed7b18b42e"},
-    {file = "regex-2021.8.28-cp38-cp38-win32.whl", hash = "sha256:473858730ef6d6ff7f7d5f19452184cd0caa062a20047f6d6f3e135a4648865d"},
-    {file = "regex-2021.8.28-cp38-cp38-win_amd64.whl", hash = "sha256:31a99a4796bf5aefc8351e98507b09e1b09115574f7c9dbb9cf2111f7220d2e2"},
-    {file = "regex-2021.8.28-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:04f6b9749e335bb0d2f68c707f23bb1773c3fb6ecd10edf0f04df12a8920d468"},
-    {file = "regex-2021.8.28-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9b006628fe43aa69259ec04ca258d88ed19b64791693df59c422b607b6ece8bb"},
-    {file = "regex-2021.8.28-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:121f4b3185feaade3f85f70294aef3f777199e9b5c0c0245c774ae884b110a2d"},
-    {file = "regex-2021.8.28-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a577a21de2ef8059b58f79ff76a4da81c45a75fe0bfb09bc8b7bb4293fa18983"},
-    {file = "regex-2021.8.28-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1743345e30917e8c574f273f51679c294effba6ad372db1967852f12c76759d8"},
-    {file = "regex-2021.8.28-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e1e8406b895aba6caa63d9fd1b6b1700d7e4825f78ccb1e5260551d168db38ed"},
-    {file = "regex-2021.8.28-cp39-cp39-win32.whl", hash = "sha256:ed283ab3a01d8b53de3a05bfdf4473ae24e43caee7dcb5584e86f3f3e5ab4374"},
-    {file = "regex-2021.8.28-cp39-cp39-win_amd64.whl", hash = "sha256:610b690b406653c84b7cb6091facb3033500ee81089867ee7d59e675f9ca2b73"},
-    {file = "regex-2021.8.28.tar.gz", hash = "sha256:f585cbbeecb35f35609edccb95efd95a3e35824cd7752b586503f7e6087303f1"},
+    {file = "regex-2021.10.23-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:45b65d6a275a478ac2cbd7fdbf7cc93c1982d613de4574b56fd6972ceadb8395"},
+    {file = "regex-2021.10.23-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:74d071dbe4b53c602edd87a7476ab23015a991374ddb228d941929ad7c8c922e"},
+    {file = "regex-2021.10.23-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:34d870f9f27f2161709054d73646fc9aca49480617a65533fc2b4611c518e455"},
+    {file = "regex-2021.10.23-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2fb698037c35109d3c2e30f2beb499e5ebae6e4bb8ff2e60c50b9a805a716f79"},
+    {file = "regex-2021.10.23-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:cb46b542133999580ffb691baf67410306833ee1e4f58ed06b6a7aaf4e046952"},
+    {file = "regex-2021.10.23-cp310-cp310-win32.whl", hash = "sha256:5e9c9e0ce92f27cef79e28e877c6b6988c48b16942258f3bc55d39b5f911df4f"},
+    {file = "regex-2021.10.23-cp310-cp310-win_amd64.whl", hash = "sha256:ab7c5684ff3538b67df3f93d66bd3369b749087871ae3786e70ef39e601345b0"},
+    {file = "regex-2021.10.23-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:de557502c3bec8e634246588a94e82f1ee1b9dfcfdc453267c4fb652ff531570"},
+    {file = "regex-2021.10.23-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ee684f139c91e69fe09b8e83d18b4d63bf87d9440c1eb2eeb52ee851883b1b29"},
+    {file = "regex-2021.10.23-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5095a411c8479e715784a0c9236568ae72509450ee2226b649083730f3fadfc6"},
+    {file = "regex-2021.10.23-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b568809dca44cb75c8ebb260844ea98252c8c88396f9d203f5094e50a70355f"},
+    {file = "regex-2021.10.23-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:eb672217f7bd640411cfc69756ce721d00ae600814708d35c930930f18e8029f"},
+    {file = "regex-2021.10.23-cp36-cp36m-win32.whl", hash = "sha256:a7a986c45d1099a5de766a15de7bee3840b1e0e1a344430926af08e5297cf666"},
+    {file = "regex-2021.10.23-cp36-cp36m-win_amd64.whl", hash = "sha256:6d7722136c6ed75caf84e1788df36397efdc5dbadab95e59c2bba82d4d808a4c"},
+    {file = "regex-2021.10.23-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:9f665677e46c5a4d288ece12fdedf4f4204a422bb28ff05f0e6b08b7447796d1"},
+    {file = "regex-2021.10.23-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:450dc27483548214314640c89a0f275dbc557968ed088da40bde7ef8fb52829e"},
+    {file = "regex-2021.10.23-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:129472cd06062fb13e7b4670a102951a3e655e9b91634432cfbdb7810af9d710"},
+    {file = "regex-2021.10.23-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a940ca7e7189d23da2bfbb38973832813eab6bd83f3bf89a977668c2f813deae"},
+    {file = "regex-2021.10.23-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:530fc2bbb3dc1ebb17f70f7b234f90a1dd43b1b489ea38cea7be95fb21cdb5c7"},
+    {file = "regex-2021.10.23-cp37-cp37m-win32.whl", hash = "sha256:ded0c4a3eee56b57fcb2315e40812b173cafe79d2f992d50015f4387445737fa"},
+    {file = "regex-2021.10.23-cp37-cp37m-win_amd64.whl", hash = "sha256:391703a2abf8013d95bae39145d26b4e21531ab82e22f26cd3a181ee2644c234"},
+    {file = "regex-2021.10.23-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:be04739a27be55631069b348dda0c81d8ea9822b5da10b8019b789e42d1fe452"},
+    {file = "regex-2021.10.23-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13ec99df95003f56edcd307db44f06fbeb708c4ccdcf940478067dd62353181e"},
+    {file = "regex-2021.10.23-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:8d1cdcda6bd16268316d5db1038965acf948f2a6f43acc2e0b1641ceab443623"},
+    {file = "regex-2021.10.23-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0c186691a7995ef1db61205e00545bf161fb7b59cdb8c1201c89b333141c438a"},
+    {file = "regex-2021.10.23-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2b20f544cbbeffe171911f6ce90388ad36fe3fad26b7c7a35d4762817e9ea69c"},
+    {file = "regex-2021.10.23-cp38-cp38-win32.whl", hash = "sha256:c0938ddd60cc04e8f1faf7a14a166ac939aac703745bfcd8e8f20322a7373019"},
+    {file = "regex-2021.10.23-cp38-cp38-win_amd64.whl", hash = "sha256:56f0c81c44638dfd0e2367df1a331b4ddf2e771366c4b9c5d9a473de75e3e1c7"},
+    {file = "regex-2021.10.23-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:80bb5d2e92b2258188e7dcae5b188c7bf868eafdf800ea6edd0fbfc029984a88"},
+    {file = "regex-2021.10.23-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e1dae12321b31059a1a72aaa0e6ba30156fe7e633355e445451e4021b8e122b6"},
+    {file = "regex-2021.10.23-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1f2b59c28afc53973d22e7bc18428721ee8ca6079becf1b36571c42627321c65"},
+    {file = "regex-2021.10.23-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d134757a37d8640f3c0abb41f5e68b7cf66c644f54ef1cb0573b7ea1c63e1509"},
+    {file = "regex-2021.10.23-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0dcc0e71118be8c69252c207630faf13ca5e1b8583d57012aae191e7d6d28b84"},
+    {file = "regex-2021.10.23-cp39-cp39-win32.whl", hash = "sha256:a30513828180264294953cecd942202dfda64e85195ae36c265daf4052af0464"},
+    {file = "regex-2021.10.23-cp39-cp39-win_amd64.whl", hash = "sha256:0f7552429dd39f70057ac5d0e897e5bfe211629652399a21671e53f2a9693a4e"},
+    {file = "regex-2021.10.23.tar.gz", hash = "sha256:f3f9a91d3cc5e5b0ddf1043c0ae5fa4852f18a1c0050318baf5fc7930ecc1f9c"},
 ]
 requests = [
     {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},
@@ -854,9 +837,13 @@ toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
+tomli = [
+    {file = "tomli-1.2.2-py3-none-any.whl", hash = "sha256:f04066f68f5554911363063a30b108d2b5a5b1a010aa8b6132af78489fe3aade"},
+    {file = "tomli-1.2.2.tar.gz", hash = "sha256:c6ce0015eb38820eaf32b5db832dbc26deb3dd427bd5f6556cf0acac2c214fee"},
+]
 tox = [
-    {file = "tox-3.24.3-py2.py3-none-any.whl", hash = "sha256:9fbf8e2ab758b2a5e7cb2c72945e4728089934853076f67ef18d7575c8ab6b88"},
-    {file = "tox-3.24.3.tar.gz", hash = "sha256:c6c4e77705ada004283610fd6d9ba4f77bc85d235447f875df9f0ba1bc23b634"},
+    {file = "tox-3.24.4-py2.py3-none-any.whl", hash = "sha256:5e274227a53dc9ef856767c21867377ba395992549f02ce55eb549f9fb9a8d10"},
+    {file = "tox-3.24.4.tar.gz", hash = "sha256:c30b57fa2477f1fb7c36aa1d83292d5c2336cd0018119e1b1c17340e2c2708ca"},
 ]
 typed-ast = [
     {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6"},
@@ -896,17 +883,67 @@ typing-extensions = [
     {file = "typing_extensions-3.10.0.2.tar.gz", hash = "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e"},
 ]
 urllib3 = [
-    {file = "urllib3-1.26.6-py2.py3-none-any.whl", hash = "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4"},
-    {file = "urllib3-1.26.6.tar.gz", hash = "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"},
+    {file = "urllib3-1.26.7-py2.py3-none-any.whl", hash = "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"},
+    {file = "urllib3-1.26.7.tar.gz", hash = "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.7.2-py2.py3-none-any.whl", hash = "sha256:e4670891b3a03eb071748c569a87cceaefbf643c5bac46d996c5a45c34aa0f06"},
-    {file = "virtualenv-20.7.2.tar.gz", hash = "sha256:9ef4e8ee4710826e98ff3075c9a4739e2cb1040de6a2a8d35db0055840dc96a0"},
+    {file = "virtualenv-20.9.0-py2.py3-none-any.whl", hash = "sha256:1d145deec2da86b29026be49c775cc5a9aab434f85f7efef98307fb3965165de"},
+    {file = "virtualenv-20.9.0.tar.gz", hash = "sha256:bb55ace18de14593947354e5e6cd1be75fb32c3329651da62e92bf5d0aab7213"},
 ]
 wrapt = [
-    {file = "wrapt-1.12.1.tar.gz", hash = "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"},
+    {file = "wrapt-1.13.3-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:e05e60ff3b2b0342153be4d1b597bbcfd8330890056b9619f4ad6b8d5c96a81a"},
+    {file = "wrapt-1.13.3-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:85148f4225287b6a0665eef08a178c15097366d46b210574a658c1ff5b377489"},
+    {file = "wrapt-1.13.3-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:2dded5496e8f1592ec27079b28b6ad2a1ef0b9296d270f77b8e4a3a796cf6909"},
+    {file = "wrapt-1.13.3-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:e94b7d9deaa4cc7bac9198a58a7240aaf87fe56c6277ee25fa5b3aa1edebd229"},
+    {file = "wrapt-1.13.3-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:498e6217523111d07cd67e87a791f5e9ee769f9241fcf8a379696e25806965af"},
+    {file = "wrapt-1.13.3-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:ec7e20258ecc5174029a0f391e1b948bf2906cd64c198a9b8b281b811cbc04de"},
+    {file = "wrapt-1.13.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:87883690cae293541e08ba2da22cacaae0a092e0ed56bbba8d018cc486fbafbb"},
+    {file = "wrapt-1.13.3-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:f99c0489258086308aad4ae57da9e8ecf9e1f3f30fa35d5e170b4d4896554d80"},
+    {file = "wrapt-1.13.3-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:6a03d9917aee887690aa3f1747ce634e610f6db6f6b332b35c2dd89412912bca"},
+    {file = "wrapt-1.13.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:936503cb0a6ed28dbfa87e8fcd0a56458822144e9d11a49ccee6d9a8adb2ac44"},
+    {file = "wrapt-1.13.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f9c51d9af9abb899bd34ace878fbec8bf357b3194a10c4e8e0a25512826ef056"},
+    {file = "wrapt-1.13.3-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:220a869982ea9023e163ba915077816ca439489de6d2c09089b219f4e11b6785"},
+    {file = "wrapt-1.13.3-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:0877fe981fd76b183711d767500e6b3111378ed2043c145e21816ee589d91096"},
+    {file = "wrapt-1.13.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:43e69ffe47e3609a6aec0fe723001c60c65305784d964f5007d5b4fb1bc6bf33"},
+    {file = "wrapt-1.13.3-cp310-cp310-win32.whl", hash = "sha256:78dea98c81915bbf510eb6a3c9c24915e4660302937b9ae05a0947164248020f"},
+    {file = "wrapt-1.13.3-cp310-cp310-win_amd64.whl", hash = "sha256:ea3e746e29d4000cd98d572f3ee2a6050a4f784bb536f4ac1f035987fc1ed83e"},
+    {file = "wrapt-1.13.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:8c73c1a2ec7c98d7eaded149f6d225a692caa1bd7b2401a14125446e9e90410d"},
+    {file = "wrapt-1.13.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:086218a72ec7d986a3eddb7707c8c4526d677c7b35e355875a0fe2918b059179"},
+    {file = "wrapt-1.13.3-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:e92d0d4fa68ea0c02d39f1e2f9cb5bc4b4a71e8c442207433d8db47ee79d7aa3"},
+    {file = "wrapt-1.13.3-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:d4a5f6146cfa5c7ba0134249665acd322a70d1ea61732723c7d3e8cc0fa80755"},
+    {file = "wrapt-1.13.3-cp35-cp35m-win32.whl", hash = "sha256:8aab36778fa9bba1a8f06a4919556f9f8c7b33102bd71b3ab307bb3fecb21851"},
+    {file = "wrapt-1.13.3-cp35-cp35m-win_amd64.whl", hash = "sha256:944b180f61f5e36c0634d3202ba8509b986b5fbaf57db3e94df11abee244ba13"},
+    {file = "wrapt-1.13.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:2ebdde19cd3c8cdf8df3fc165bc7827334bc4e353465048b36f7deeae8ee0918"},
+    {file = "wrapt-1.13.3-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:610f5f83dd1e0ad40254c306f4764fcdc846641f120c3cf424ff57a19d5f7ade"},
+    {file = "wrapt-1.13.3-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5601f44a0f38fed36cc07db004f0eedeaadbdcec90e4e90509480e7e6060a5bc"},
+    {file = "wrapt-1.13.3-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:e6906d6f48437dfd80464f7d7af1740eadc572b9f7a4301e7dd3d65db285cacf"},
+    {file = "wrapt-1.13.3-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:766b32c762e07e26f50d8a3468e3b4228b3736c805018e4b0ec8cc01ecd88125"},
+    {file = "wrapt-1.13.3-cp36-cp36m-win32.whl", hash = "sha256:5f223101f21cfd41deec8ce3889dc59f88a59b409db028c469c9b20cfeefbe36"},
+    {file = "wrapt-1.13.3-cp36-cp36m-win_amd64.whl", hash = "sha256:f122ccd12fdc69628786d0c947bdd9cb2733be8f800d88b5a37c57f1f1d73c10"},
+    {file = "wrapt-1.13.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:46f7f3af321a573fc0c3586612db4decb7eb37172af1bc6173d81f5b66c2e068"},
+    {file = "wrapt-1.13.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:778fd096ee96890c10ce96187c76b3e99b2da44e08c9e24d5652f356873f6709"},
+    {file = "wrapt-1.13.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0cb23d36ed03bf46b894cfec777eec754146d68429c30431c99ef28482b5c1df"},
+    {file = "wrapt-1.13.3-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:96b81ae75591a795d8c90edc0bfaab44d3d41ffc1aae4d994c5aa21d9b8e19a2"},
+    {file = "wrapt-1.13.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:7dd215e4e8514004c8d810a73e342c536547038fb130205ec4bba9f5de35d45b"},
+    {file = "wrapt-1.13.3-cp37-cp37m-win32.whl", hash = "sha256:47f0a183743e7f71f29e4e21574ad3fa95676136f45b91afcf83f6a050914829"},
+    {file = "wrapt-1.13.3-cp37-cp37m-win_amd64.whl", hash = "sha256:fd76c47f20984b43d93de9a82011bb6e5f8325df6c9ed4d8310029a55fa361ea"},
+    {file = "wrapt-1.13.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b73d4b78807bd299b38e4598b8e7bd34ed55d480160d2e7fdaabd9931afa65f9"},
+    {file = "wrapt-1.13.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ec9465dd69d5657b5d2fa6133b3e1e989ae27d29471a672416fd729b429eb554"},
+    {file = "wrapt-1.13.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:dd91006848eb55af2159375134d724032a2d1d13bcc6f81cd8d3ed9f2b8e846c"},
+    {file = "wrapt-1.13.3-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:ae9de71eb60940e58207f8e71fe113c639da42adb02fb2bcbcaccc1ccecd092b"},
+    {file = "wrapt-1.13.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:51799ca950cfee9396a87f4a1240622ac38973b6df5ef7a41e7f0b98797099ce"},
+    {file = "wrapt-1.13.3-cp38-cp38-win32.whl", hash = "sha256:4b9c458732450ec42578b5642ac53e312092acf8c0bfce140ada5ca1ac556f79"},
+    {file = "wrapt-1.13.3-cp38-cp38-win_amd64.whl", hash = "sha256:7dde79d007cd6dfa65afe404766057c2409316135cb892be4b1c768e3f3a11cb"},
+    {file = "wrapt-1.13.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:981da26722bebb9247a0601e2922cedf8bb7a600e89c852d063313102de6f2cb"},
+    {file = "wrapt-1.13.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:705e2af1f7be4707e49ced9153f8d72131090e52be9278b5dbb1498c749a1e32"},
+    {file = "wrapt-1.13.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:25b1b1d5df495d82be1c9d2fad408f7ce5ca8a38085e2da41bb63c914baadff7"},
+    {file = "wrapt-1.13.3-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:77416e6b17926d953b5c666a3cb718d5945df63ecf922af0ee576206d7033b5e"},
+    {file = "wrapt-1.13.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:865c0b50003616f05858b22174c40ffc27a38e67359fa1495605f96125f76640"},
+    {file = "wrapt-1.13.3-cp39-cp39-win32.whl", hash = "sha256:0a017a667d1f7411816e4bf214646d0ad5b1da2c1ea13dec6c162736ff25a374"},
+    {file = "wrapt-1.13.3-cp39-cp39-win_amd64.whl", hash = "sha256:81bd7c90d28a4b2e1df135bfbd7c23aee3050078ca6441bead44c42483f9ebfb"},
+    {file = "wrapt-1.13.3.tar.gz", hash = "sha256:1fea9cd438686e6682271d36f3481a9f3636195578bab9ca3382e2f5f01fc185"},
 ]
 zipp = [
-    {file = "zipp-3.5.0-py3-none-any.whl", hash = "sha256:957cfda87797e389580cb8b9e3870841ca991e2125350677b2ca83a0e99390a3"},
-    {file = "zipp-3.5.0.tar.gz", hash = "sha256:f5812b1e007e48cff63449a5e9f4e7ebea716b4111f9c4f9a645f91d579bf0c4"},
+    {file = "zipp-3.6.0-py3-none-any.whl", hash = "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"},
+    {file = "zipp-3.6.0.tar.gz", hash = "sha256:71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -68,7 +68,6 @@ python-versions = ">=3.6"
 [package.dependencies]
 appdirs = "*"
 click = ">=7.1.2"
-dataclasses = {version = ">=0.6", markers = "python_version < \"3.7\""}
 mypy-extensions = ">=0.4.3"
 pathspec = ">=0.6,<1"
 regex = ">=2020.1.8"
@@ -131,14 +130,6 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 toml = ["toml"]
 
 [[package]]
-name = "dataclasses"
-version = "0.8"
-description = "A backport of the dataclasses module for Python 3.6"
-category = "dev"
-optional = false
-python-versions = ">=3.6, <3.7"
-
-[[package]]
 name = "distlib"
 version = "0.3.2"
 description = "Distribution utilities"
@@ -194,21 +185,6 @@ perf = ["ipython"]
 testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
-name = "importlib-resources"
-version = "5.2.2"
-description = "Read resources from Python packages"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
-
-[package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-black (>=0.3.7)", "pytest-mypy"]
-
-[[package]]
 name = "iniconfig"
 version = "1.1.1"
 description = "iniconfig: brain-dead simple config-ini parsing"
@@ -218,16 +194,17 @@ python-versions = "*"
 
 [[package]]
 name = "isort"
-version = "5.8.0"
+version = "5.9.3"
 description = "A Python utility / library to sort Python imports."
-category = "dev"
+category = "main"
 optional = false
-python-versions = ">=3.6,<4.0"
+python-versions = ">=3.6.1,<4.0"
 
 [package.extras]
 pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
 requirements_deprecated_finder = ["pipreqs", "pip-api"]
 colors = ["colorama (>=0.4.3,<0.5.0)"]
+plugins = ["setuptools"]
 
 [[package]]
 name = "lazy-object-proxy"
@@ -502,7 +479,7 @@ python-versions = "*"
 name = "typing-extensions"
 version = "3.10.0.2"
 description = "Backported and Experimental Type Hints for Python 3.5+"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -532,7 +509,6 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 distlib = ">=0.3.1,<1"
 filelock = ">=3.0.0,<4"
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
-importlib-resources = {version = ">=1.0", markers = "python_version < \"3.7\""}
 platformdirs = ">=2,<3"
 six = ">=1.9.0,<2"
 
@@ -562,8 +538,8 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.6"
-content-hash = "c3d0fab1adc9b17debfcecb32603c372413d1d5d1b0995e2e63695f3c009003f"
+python-versions = "^3.7"
+content-hash = "f826accd174a99a2ea3994ec547c2f425c1e730f30c998b70146e706f65cb23f"
 
 [metadata.files]
 appdirs = [
@@ -659,10 +635,6 @@ coverage = [
     {file = "coverage-5.5-pp37-none-any.whl", hash = "sha256:2a3859cb82dcbda1cfd3e6f71c27081d18aa251d20a17d87d26d4cd216fb0af4"},
     {file = "coverage-5.5.tar.gz", hash = "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c"},
 ]
-dataclasses = [
-    {file = "dataclasses-0.8-py3-none-any.whl", hash = "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf"},
-    {file = "dataclasses-0.8.tar.gz", hash = "sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97"},
-]
 distlib = [
     {file = "distlib-0.3.2-py2.py3-none-any.whl", hash = "sha256:23e223426b28491b1ced97dc3bbe183027419dfc7982b4fa2f05d5f3ff10711c"},
     {file = "distlib-0.3.2.zip", hash = "sha256:106fef6dc37dd8c0e2c0a60d3fca3e77460a48907f335fa28420463a6f799736"},
@@ -683,17 +655,13 @@ importlib-metadata = [
     {file = "importlib_metadata-4.8.1-py3-none-any.whl", hash = "sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15"},
     {file = "importlib_metadata-4.8.1.tar.gz", hash = "sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1"},
 ]
-importlib-resources = [
-    {file = "importlib_resources-5.2.2-py3-none-any.whl", hash = "sha256:2480d8e07d1890056cb53c96e3de44fead9c62f2ba949b0f2e4c4345f4afa977"},
-    {file = "importlib_resources-5.2.2.tar.gz", hash = "sha256:a65882a4d0fe5fbf702273456ba2ce74fe44892c25e42e057aca526b702a6d4b"},
-]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 isort = [
-    {file = "isort-5.8.0-py3-none-any.whl", hash = "sha256:2bb1680aad211e3c9944dbce1d4ba09a989f04e238296c87fe2139faa26d655d"},
-    {file = "isort-5.8.0.tar.gz", hash = "sha256:0a943902919f65c5684ac4e0154b1ad4fac6dcaa5d9f3426b732f1c8b5419be6"},
+    {file = "isort-5.9.3-py3-none-any.whl", hash = "sha256:e17d6e2b81095c9db0a03a8025a957f334d6ea30b26f9ec70805411e5c7c81f2"},
+    {file = "isort-5.9.3.tar.gz", hash = "sha256:9c2ea1e62d871267b78307fe511c0838ba0da28698c5732d54e2790bf3ba9899"},
 ]
 lazy-object-proxy = [
     {file = "lazy-object-proxy-1.6.0.tar.gz", hash = "sha256:489000d368377571c6f982fba6497f2aa13c6d1facc40660963da62f5c379726"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -43,6 +43,21 @@ tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)"
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
 
 [[package]]
+name = "backports.entry-points-selectable"
+version = "1.1.0"
+description = "Compatibility shim providing selectable entry points for older implementations"
+category = "dev"
+optional = false
+python-versions = ">=2.7"
+
+[package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=4.6)", "pytest-flake8", "pytest-cov", "pytest-black (>=0.3.7)", "pytest-mypy", "pytest-checkdocs (>=2.4)", "pytest-enabler (>=1.0.1)"]
+
+[[package]]
 name = "black"
 version = "20.8b1"
 description = "The uncompromising code formatter."
@@ -124,6 +139,36 @@ optional = false
 python-versions = ">=3.6, <3.7"
 
 [[package]]
+name = "distlib"
+version = "0.3.2"
+description = "Distribution utilities"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "filelock"
+version = "3.0.12"
+description = "A platform independent file lock."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "flake8"
+version = "3.9.2"
+description = "the modular source code checker: pep8 pyflakes and co"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+mccabe = ">=0.6.0,<0.7.0"
+pycodestyle = ">=2.7.0,<2.8.0"
+pyflakes = ">=2.3.0,<2.4.0"
+
+[[package]]
 name = "idna"
 version = "3.2"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -147,6 +192,21 @@ zipp = ">=0.5"
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 perf = ["ipython"]
 testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+
+[[package]]
+name = "importlib-resources"
+version = "5.2.2"
+description = "Read resources from Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [[package]]
 name = "iniconfig"
@@ -184,6 +244,24 @@ description = "McCabe checker, plugin for flake8"
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "mypy"
+version = "0.910"
+description = "Optional static typing for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+mypy-extensions = ">=0.4.3,<0.5.0"
+toml = "*"
+typed-ast = {version = ">=1.4.0,<1.5.0", markers = "python_version < \"3.8\""}
+typing-extensions = ">=3.7.4"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+python2 = ["typed-ast (>=1.4.0,<1.5.0)"]
 
 [[package]]
 name = "mypy-extensions"
@@ -243,6 +321,22 @@ testing = ["pytest", "pytest-benchmark"]
 name = "py"
 version = "1.10.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pycodestyle"
+version = "2.7.0"
+description = "Python style guide checker"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pyflakes"
+version = "2.3.1"
+description = "passive checker of Python programs"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
@@ -358,12 +452,43 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
 use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
 category = "dev"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "tox"
+version = "3.24.3"
+description = "tox is a generic virtualenv management and test command line tool"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[package.dependencies]
+colorama = {version = ">=0.4.1", markers = "platform_system == \"Windows\""}
+filelock = ">=3.0.0"
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+packaging = ">=14"
+pluggy = ">=0.12.0"
+py = ">=1.4.17"
+six = ">=1.14.0"
+toml = ">=0.9.4"
+virtualenv = ">=16.0.0,<20.0.0 || >20.0.0,<20.0.1 || >20.0.1,<20.0.2 || >20.0.2,<20.0.3 || >20.0.3,<20.0.4 || >20.0.4,<20.0.5 || >20.0.5,<20.0.6 || >20.0.6,<20.0.7 || >20.0.7"
+
+[package.extras]
+docs = ["pygments-github-lexers (>=0.0.5)", "sphinx (>=2.0.0)", "sphinxcontrib-autoprogram (>=0.1.5)", "towncrier (>=18.5.0)"]
+testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "psutil (>=5.6.1)", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-randomly (>=1.0.0)", "pytest-xdist (>=1.22.2)", "pathlib2 (>=2.3.3)"]
 
 [[package]]
 name = "typed-ast"
@@ -395,6 +520,27 @@ secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "cer
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
+name = "virtualenv"
+version = "20.7.2"
+description = "Virtual Python Environment builder"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[package.dependencies]
+"backports.entry-points-selectable" = ">=1.0.4"
+distlib = ">=0.3.1,<1"
+filelock = ">=3.0.0,<4"
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+importlib-resources = {version = ">=1.0", markers = "python_version < \"3.7\""}
+platformdirs = ">=2,<3"
+six = ">=1.9.0,<2"
+
+[package.extras]
+docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=19.9.0rc1)"]
+testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "packaging (>=20.0)"]
+
+[[package]]
 name = "wrapt"
 version = "1.12.1"
 description = "Module for decorators, wrappers and monkey patching."
@@ -417,7 +563,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "5e46c55bd77d631851f1b90584706a66fe4983f1735309c1a1e25e465886e943"
+content-hash = "c3d0fab1adc9b17debfcecb32603c372413d1d5d1b0995e2e63695f3c009003f"
 
 [metadata.files]
 appdirs = [
@@ -435,6 +581,10 @@ atomicwrites = [
 attrs = [
     {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},
     {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
+]
+"backports.entry-points-selectable" = [
+    {file = "backports.entry_points_selectable-1.1.0-py2.py3-none-any.whl", hash = "sha256:a6d9a871cde5e15b4c4a53e3d43ba890cc6861ec1332c9c2428c92f977192acc"},
+    {file = "backports.entry_points_selectable-1.1.0.tar.gz", hash = "sha256:988468260ec1c196dab6ae1149260e2f5472c9110334e5d51adcb77867361f6a"},
 ]
 black = [
     {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
@@ -513,6 +663,18 @@ dataclasses = [
     {file = "dataclasses-0.8-py3-none-any.whl", hash = "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf"},
     {file = "dataclasses-0.8.tar.gz", hash = "sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97"},
 ]
+distlib = [
+    {file = "distlib-0.3.2-py2.py3-none-any.whl", hash = "sha256:23e223426b28491b1ced97dc3bbe183027419dfc7982b4fa2f05d5f3ff10711c"},
+    {file = "distlib-0.3.2.zip", hash = "sha256:106fef6dc37dd8c0e2c0a60d3fca3e77460a48907f335fa28420463a6f799736"},
+]
+filelock = [
+    {file = "filelock-3.0.12-py3-none-any.whl", hash = "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"},
+    {file = "filelock-3.0.12.tar.gz", hash = "sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59"},
+]
+flake8 = [
+    {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
+    {file = "flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b"},
+]
 idna = [
     {file = "idna-3.2-py3-none-any.whl", hash = "sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a"},
     {file = "idna-3.2.tar.gz", hash = "sha256:467fbad99067910785144ce333826c71fb0e63a425657295239737f7ecd125f3"},
@@ -520,6 +682,10 @@ idna = [
 importlib-metadata = [
     {file = "importlib_metadata-4.8.1-py3-none-any.whl", hash = "sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15"},
     {file = "importlib_metadata-4.8.1.tar.gz", hash = "sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1"},
+]
+importlib-resources = [
+    {file = "importlib_resources-5.2.2-py3-none-any.whl", hash = "sha256:2480d8e07d1890056cb53c96e3de44fead9c62f2ba949b0f2e4c4345f4afa977"},
+    {file = "importlib_resources-5.2.2.tar.gz", hash = "sha256:a65882a4d0fe5fbf702273456ba2ce74fe44892c25e42e057aca526b702a6d4b"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -557,6 +723,31 @@ mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
+mypy = [
+    {file = "mypy-0.910-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:a155d80ea6cee511a3694b108c4494a39f42de11ee4e61e72bc424c490e46457"},
+    {file = "mypy-0.910-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:b94e4b785e304a04ea0828759172a15add27088520dc7e49ceade7834275bedb"},
+    {file = "mypy-0.910-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:088cd9c7904b4ad80bec811053272986611b84221835e079be5bcad029e79dd9"},
+    {file = "mypy-0.910-cp35-cp35m-win_amd64.whl", hash = "sha256:adaeee09bfde366d2c13fe6093a7df5df83c9a2ba98638c7d76b010694db760e"},
+    {file = "mypy-0.910-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:ecd2c3fe726758037234c93df7e98deb257fd15c24c9180dacf1ef829da5f921"},
+    {file = "mypy-0.910-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:d9dd839eb0dc1bbe866a288ba3c1afc33a202015d2ad83b31e875b5905a079b6"},
+    {file = "mypy-0.910-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:3e382b29f8e0ccf19a2df2b29a167591245df90c0b5a2542249873b5c1d78212"},
+    {file = "mypy-0.910-cp36-cp36m-win_amd64.whl", hash = "sha256:53fd2eb27a8ee2892614370896956af2ff61254c275aaee4c230ae771cadd885"},
+    {file = "mypy-0.910-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b6fb13123aeef4a3abbcfd7e71773ff3ff1526a7d3dc538f3929a49b42be03f0"},
+    {file = "mypy-0.910-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e4dab234478e3bd3ce83bac4193b2ecd9cf94e720ddd95ce69840273bf44f6de"},
+    {file = "mypy-0.910-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:7df1ead20c81371ccd6091fa3e2878559b5c4d4caadaf1a484cf88d93ca06703"},
+    {file = "mypy-0.910-cp37-cp37m-win_amd64.whl", hash = "sha256:0aadfb2d3935988ec3815952e44058a3100499f5be5b28c34ac9d79f002a4a9a"},
+    {file = "mypy-0.910-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ec4e0cd079db280b6bdabdc807047ff3e199f334050db5cbb91ba3e959a67504"},
+    {file = "mypy-0.910-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:119bed3832d961f3a880787bf621634ba042cb8dc850a7429f643508eeac97b9"},
+    {file = "mypy-0.910-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:866c41f28cee548475f146aa4d39a51cf3b6a84246969f3759cb3e9c742fc072"},
+    {file = "mypy-0.910-cp38-cp38-win_amd64.whl", hash = "sha256:ceb6e0a6e27fb364fb3853389607cf7eb3a126ad335790fa1e14ed02fba50811"},
+    {file = "mypy-0.910-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1a85e280d4d217150ce8cb1a6dddffd14e753a4e0c3cf90baabb32cefa41b59e"},
+    {file = "mypy-0.910-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:42c266ced41b65ed40a282c575705325fa7991af370036d3f134518336636f5b"},
+    {file = "mypy-0.910-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:3c4b8ca36877fc75339253721f69603a9c7fdb5d4d5a95a1a1b899d8b86a4de2"},
+    {file = "mypy-0.910-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:c0df2d30ed496a08de5daed2a9ea807d07c21ae0ab23acf541ab88c24b26ab97"},
+    {file = "mypy-0.910-cp39-cp39-win_amd64.whl", hash = "sha256:c6c2602dffb74867498f86e6129fd52a2770c48b7cd3ece77ada4fa38f94eba8"},
+    {file = "mypy-0.910-py3-none-any.whl", hash = "sha256:ef565033fa5a958e62796867b1df10c40263ea9ded87164d67572834e57a174d"},
+    {file = "mypy-0.910.tar.gz", hash = "sha256:704098302473cb31a218f1775a873b376b30b4c18229421e9e9dc8916fd16150"},
+]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
@@ -580,6 +771,14 @@ pluggy = [
 py = [
     {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
     {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
+]
+pycodestyle = [
+    {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},
+    {file = "pycodestyle-2.7.0.tar.gz", hash = "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"},
+]
+pyflakes = [
+    {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},
+    {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
 ]
 pylint = [
     {file = "pylint-2.10.2-py3-none-any.whl", hash = "sha256:e178e96b6ba171f8ef51fbce9ca30931e6acbea4a155074d80cc081596c9e852"},
@@ -679,9 +878,17 @@ requests = [
     {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},
     {file = "requests-2.26.0.tar.gz", hash = "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"},
 ]
+six = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+tox = [
+    {file = "tox-3.24.3-py2.py3-none-any.whl", hash = "sha256:9fbf8e2ab758b2a5e7cb2c72945e4728089934853076f67ef18d7575c8ab6b88"},
+    {file = "tox-3.24.3.tar.gz", hash = "sha256:c6c4e77705ada004283610fd6d9ba4f77bc85d235447f875df9f0ba1bc23b634"},
 ]
 typed-ast = [
     {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6"},
@@ -723,6 +930,10 @@ typing-extensions = [
 urllib3 = [
     {file = "urllib3-1.26.6-py2.py3-none-any.whl", hash = "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4"},
     {file = "urllib3-1.26.6.tar.gz", hash = "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"},
+]
+virtualenv = [
+    {file = "virtualenv-20.7.2-py2.py3-none-any.whl", hash = "sha256:e4670891b3a03eb071748c569a87cceaefbf643c5bac46d996c5a45c34aa0f06"},
+    {file = "virtualenv-20.7.2.tar.gz", hash = "sha256:9ef4e8ee4710826e98ff3075c9a4739e2cb1040de6a2a8d35db0055840dc96a0"},
 ]
 wrapt = [
     {file = "wrapt-1.12.1.tar.gz", hash = "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "switchbot-client"
-version = "0.1.2"
+version = "0.2.0"
 description = "A Python client library for SwitchBot API."
 license = "Apache-2.0 or MIT"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ requires = ["poetry_core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.pylint."message control"]
-disable = ["C0114,C0115,C0116,R0903"]
+disable = ["C0114,C0115,C0116,R0801,R0903,R0913"]
 
 [tool.black]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,19 +22,19 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.7"
 requests = "^2.0"
-PyYAML = "^5.1"
-isort = "^5.9.3"
+PyYAML = "^5.4.1"
 typing-extensions = "^3.10.0"
 
 [tool.poetry.dev-dependencies]
-black = ">=18.5b1"
-pylint = "^2.0"
-pytest = "^6.0"
-pytest-cov = "^2.0"
-pytest-mock = "^3.0"
-flake8 = "^3.9.2"
+black = ">=20.8b1"
+flake8 = "^4.0.1"
+isort = "^5.9.3"
 mypy = "^0.910"
-tox = "^3.24.3"
+pylint = "^2.10.2"
+pytest = "^6.2.5"
+pytest-cov = "^2.12.1"
+pytest-mock = "^3.6.1"
+tox = "^3.24.4"
 
 [build-system]
 requires = ["poetry_core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,11 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.7"
 requests = "^2.0"
 PyYAML = "^5.1"
+isort = "^5.9.3"
+typing-extensions = "^3.10.0"
 
 [tool.poetry.dev-dependencies]
 black = ">=18.5b1"
@@ -43,3 +45,6 @@ disable = ["C0114,C0115,C0116,R0903"]
 
 [tool.black]
 line-length = 100
+
+[tool.isort]
+profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,12 @@ pylint = "^2.0"
 pytest = "^6.0"
 pytest-cov = "^2.0"
 pytest-mock = "^3.0"
+flake8 = "^3.9.2"
+mypy = "^0.910"
+tox = "^3.24.3"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry_core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.pylint."message control"]

--- a/scripts/fix.sh
+++ b/scripts/fix.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -eu
+cd "$( dirname "$0" )"/..
+poetry run isort switchbot_client tests
+poetry run black switchbot_client tests

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,5 +1,0 @@
-#!/bin/bash -eu
-source .venv/bin/activate
-poetry run pylint switchbot_client
-poetry run black switchbot_client tests --check --diff
-poetry run pytest tests

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -eu
+cd "$( dirname "$0" )"/..
+poetry run tox --quiet

--- a/switchbot_client/__init__.py
+++ b/switchbot_client/__init__.py
@@ -1,7 +1,9 @@
-from switchbot_client.client import SwitchBotAPIClient, SwitchBotAPIResponse
-from switchbot_client.enums import DeviceType, RemoteType, ControlCommand
+from switchbot_client.api import SwitchBotAPIClient, SwitchBotAPIResponse
+from switchbot_client.client import SwitchBotClient
+from switchbot_client.enums import ControlCommand, DeviceType, RemoteType
 
 __all__ = [
+    "SwitchBotClient",
     "SwitchBotAPIClient",
     "SwitchBotAPIResponse",
     "DeviceType",

--- a/switchbot_client/__init__.py
+++ b/switchbot_client/__init__.py
@@ -1,2 +1,10 @@
 from switchbot_client.client import SwitchBotAPIClient, SwitchBotAPIResponse
 from switchbot_client.enums import DeviceType, RemoteType, ControlCommand
+
+__all__ = [
+    "SwitchBotAPIClient",
+    "SwitchBotAPIResponse",
+    "DeviceType",
+    "RemoteType",
+    "ControlCommand",
+]

--- a/switchbot_client/api.py
+++ b/switchbot_client/api.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 import requests
 import yaml
 
+from switchbot_client.constants import AppConstants
+
 
 @dataclass
 class SwitchBotAPIResponse:
@@ -109,7 +111,12 @@ class SwitchBotAPIClient:
         return f"{self.api_host_domain}/{endpoint}"
 
     def _headers(self):
-        return {"content-type": "application/json", "authorization": self.token}
+        version = AppConstants.VERSION
+        return {
+            "content-type": "application/json",
+            "authorization": self.token,
+            "user-agent": f"switchbot-client/{version}",
+        }
 
     def _load_config(self):
         config_file_path = self.config_file_path()

--- a/switchbot_client/api.py
+++ b/switchbot_client/api.py
@@ -1,0 +1,131 @@
+import json
+import os
+from dataclasses import dataclass
+
+import requests
+import yaml
+
+
+@dataclass
+class SwitchBotAPIResponse:
+    status_code: int
+    message: str
+    body: dict
+
+
+class SwitchBotAPIClient:
+    """
+    A thin wrapper for SwitchBot API.
+    It returns almost raw API response.
+    https://github.com/OpenWonderLabs/SwitchBotAPI
+    """
+
+    DEFAULT_CONFIG_FILE_PATH = "~/.config/switchbot-client/config.yml"
+
+    def __init__(
+        self, token: str = None, api_host_domain: str = None, config_file_path: str = None
+    ) -> None:
+        if config_file_path is None:
+            self.__config_file_path = config_file_path
+        config = self._load_config()
+        if token is not None:
+            self.token = token
+        elif "SWITCHBOT_OPEN_TOKEN" in os.environ and len(os.environ["SWITCHBOT_OPEN_TOKEN"]) > 0:
+            self.token = os.environ["SWITCHBOT_OPEN_TOKEN"]
+        elif config is not None and "token" in config.keys():
+            self.token = config["token"]
+        else:
+            raise RuntimeError("no token specified")
+
+        if api_host_domain is not None:
+            self.api_host_domain = api_host_domain
+        elif config is not None and "api_host_domain" in config.keys():
+            self.api_host_domain = config["api_host_domain"]
+        else:
+            self.api_host_domain = "https://api.switch-bot.com"
+
+    def devices(self) -> SwitchBotAPIResponse:
+        response: requests.Response = requests.get(
+            self._uri("v1.0/devices"), headers=self._headers()
+        )
+        formatted_response: SwitchBotAPIResponse = self._check_api_response(response)
+        return formatted_response
+
+    def devices_status(self, device_id: str) -> SwitchBotAPIResponse:
+        response: requests.Response = requests.get(
+            self._uri(f"v1.0/devices/{device_id}/status"), headers=self._headers()
+        )
+        formatted_response: SwitchBotAPIResponse = self._check_api_response(response)
+        if formatted_response.status_code == 190:
+            raise RuntimeError(
+                "Wrong device ID or trying to get infrared virtual device status",
+                formatted_response,
+            )
+        return formatted_response
+
+    def devices_commands(
+        self,
+        device_id: str,
+        command: str,
+        parameter: str = None,
+        command_type: str = None,
+    ) -> SwitchBotAPIResponse:
+        payload = {
+            "command": command,
+        }
+
+        if parameter is not None:
+            payload["parameter"] = parameter
+        if command_type is not None:
+            payload["command_type"] = command_type
+        response: requests.Response = requests.post(
+            self._uri(f"v1.0/devices/{device_id}/commands"),
+            headers=self._headers(),
+            data=json.dumps(payload),
+        )
+        formatted_response: SwitchBotAPIResponse = self._check_api_response(response)
+        return formatted_response
+
+    def scenes(self) -> SwitchBotAPIResponse:
+        response: requests.Response = requests.get(
+            self._uri("v1.0/scenes"), headers=self._headers()
+        )
+        formatted_response: SwitchBotAPIResponse = self._check_api_response(response)
+        return formatted_response
+
+    def scenes_execute(self, scene_id: str) -> SwitchBotAPIResponse:
+        response: requests.Response = requests.post(
+            self._uri(f"v1.0/scenes/{scene_id}/execute"), headers=self._headers()
+        )
+        formatted_response: SwitchBotAPIResponse = self._check_api_response(response)
+        return formatted_response
+
+    def config_file_path(self):
+        if self.__config_file_path is None:
+            return os.path.expanduser(SwitchBotAPIClient.DEFAULT_CONFIG_FILE_PATH)
+        return self.__config_file_path
+
+    def _uri(self, endpoint: str):
+        return f"{self.api_host_domain}/{endpoint}"
+
+    def _headers(self):
+        return {"content-type": "application/json", "authorization": self.token}
+
+    def _load_config(self):
+        config_file_path = self.config_file_path()
+        if os.path.exists(config_file_path):
+            with open(config_file_path, encoding="utf-8") as config_file:
+                return yaml.safe_load(config_file)
+        return None
+
+    @staticmethod
+    def _check_api_response(original_response: requests.Response):
+        response = original_response.json()
+        if "message" not in response:
+            raise RuntimeError("format error")
+        if response["message"] == "Unauthorized":
+            raise RuntimeError(
+                "Http 401 Error. User permission is denied due to invalid token.",
+                original_response.text,
+            )
+        return SwitchBotAPIResponse(response["statusCode"], response["message"], response["body"])

--- a/switchbot_client/api.py
+++ b/switchbot_client/api.py
@@ -27,8 +27,7 @@ class SwitchBotAPIClient:
     def __init__(
         self, token: str = None, api_host_domain: str = None, config_file_path: str = None
     ) -> None:
-        if config_file_path is None:
-            self.__config_file_path = config_file_path
+        self.__config_file_path = config_file_path
         config = self._load_config()
         if token is not None:
             self.token = token

--- a/switchbot_client/client.py
+++ b/switchbot_client/client.py
@@ -1,8 +1,9 @@
-from typing import List
+from typing import List, Optional
 
 from switchbot_client.api import SwitchBotAPIClient
 from switchbot_client.devices.base import SwitchBotDevice
 from switchbot_client.devices.factory import SwitchBotDeviceFactory
+from switchbot_client.scenes import SwitchBotScene
 
 
 class SwitchBotClient:
@@ -21,3 +22,25 @@ class SwitchBotClient:
         devices = response["deviceList"]
         devices.extend(response["infraredRemoteList"])
         return [SwitchBotDeviceFactory.create(self.client, d) for d in devices]
+
+    def device(self, device_id: str) -> Optional[SwitchBotDevice]:
+        filtered = [d for d in self.devices() if d.device_id == device_id]
+        if len(filtered) > 1:
+            raise RuntimeError(f"duplicated device ids found: {filtered}")
+        if len(filtered) == 0:
+            return None
+        return filtered[0]
+
+    def scenes(self) -> List[SwitchBotScene]:
+        response = self.client.scenes().body
+        return [
+            SwitchBotScene(self.client, scene["sceneId"], scene["sceneName"]) for scene in response
+        ]
+
+    def scene(self, scene_id: str) -> Optional[SwitchBotScene]:
+        filtered = [s for s in self.scenes() if s.scene_id == scene_id]
+        if len(filtered) > 1:
+            raise RuntimeError(f"duplicated scene ids found: {filtered}")
+        if len(filtered) == 0:
+            return None
+        return filtered[0]

--- a/switchbot_client/client.py
+++ b/switchbot_client/client.py
@@ -1,128 +1,23 @@
-from dataclasses import dataclass
-import json
-import os
-import requests
-import yaml
+from typing import List
+
+from switchbot_client.api import SwitchBotAPIClient
+from switchbot_client.devices.base import SwitchBotDevice
+from switchbot_client.devices.factory import SwitchBotDeviceFactory
 
 
-@dataclass
-class SwitchBotAPIResponse:
-    status_code: int
-    message: str
-    body: dict
-
-
-class SwitchBotAPIClient:
+class SwitchBotClient:
     """
-    https://github.com/OpenWonderLabs/SwitchBotAPI
+    An abstract wrapper for SwitchBot API.
+    It returns wrapped objects.
     """
-
-    DEFAULT_CONFIG_FILE_PATH = "~/.config/switchbot-client/config.yml"
 
     def __init__(
         self, token: str = None, api_host_domain: str = None, config_file_path: str = None
-    ) -> None:
-        if config_file_path is None:
-            self.__config_file_path = config_file_path
-        config = self._load_config()
-        if token is not None:
-            self.token = token
-        elif "SWITCHBOT_OPEN_TOKEN" in os.environ and len(os.environ["SWITCHBOT_OPEN_TOKEN"]) > 0:
-            self.token = os.environ["SWITCHBOT_OPEN_TOKEN"]
-        elif config is not None and "token" in config.keys():
-            self.token = config["token"]
-        else:
-            raise RuntimeError("no token specified")
+    ):
+        self.client = SwitchBotAPIClient(token, api_host_domain, config_file_path)
 
-        if api_host_domain is not None:
-            self.api_host_domain = api_host_domain
-        elif config is not None and "api_host_domain" in config.keys():
-            self.api_host_domain = config["api_host_domain"]
-        else:
-            self.api_host_domain = "https://api.switch-bot.com"
-
-    def devices(self) -> SwitchBotAPIResponse:
-        response: requests.Response = requests.get(
-            self._uri("v1.0/devices"), headers=self._headers()
-        )
-        formatted_response: SwitchBotAPIResponse = self._check_api_response(response)
-        return formatted_response
-
-    def devices_status(self, device_id: str) -> SwitchBotAPIResponse:
-        response: requests.Response = requests.get(
-            self._uri(f"v1.0/devices/{device_id}/status"), headers=self._headers()
-        )
-        formatted_response: SwitchBotAPIResponse = self._check_api_response(response)
-        if formatted_response.status_code == 190:
-            raise RuntimeError(
-                "Wrong device ID or trying to get infrared virtual device status",
-                formatted_response,
-            )
-        return formatted_response
-
-    def devices_commands(
-        self,
-        device_id: str,
-        command: str,
-        parameter: str = None,
-        command_type: str = None,
-    ) -> SwitchBotAPIResponse:
-        payload = {
-            "command": command,
-        }
-
-        if parameter is not None:
-            payload["parameter"] = parameter
-        if command_type is not None:
-            payload["command_type"] = command_type
-        response: requests.Response = requests.post(
-            self._uri(f"v1.0/devices/{device_id}/commands"),
-            headers=self._headers(),
-            data=json.dumps(payload),
-        )
-        formatted_response: SwitchBotAPIResponse = self._check_api_response(response)
-        return formatted_response
-
-    def scenes(self) -> SwitchBotAPIResponse:
-        response: requests.Response = requests.get(
-            self._uri("v1.0/scenes"), headers=self._headers()
-        )
-        formatted_response: SwitchBotAPIResponse = self._check_api_response(response)
-        return formatted_response
-
-    def scenes_execute(self, scene_id: str) -> SwitchBotAPIResponse:
-        response: requests.Response = requests.post(
-            self._uri(f"v1.0/scenes/{scene_id}/execute"), headers=self._headers()
-        )
-        formatted_response: SwitchBotAPIResponse = self._check_api_response(response)
-        return formatted_response
-
-    def config_file_path(self):
-        if self.__config_file_path is None:
-            return os.path.expanduser(SwitchBotAPIClient.DEFAULT_CONFIG_FILE_PATH)
-        return self.__config_file_path
-
-    def _uri(self, endpoint: str):
-        return f"{self.api_host_domain}/{endpoint}"
-
-    def _headers(self):
-        return {"content-type": "application/json", "authorization": self.token}
-
-    def _load_config(self):
-        config_file_path = self.config_file_path()
-        if os.path.exists(config_file_path):
-            with open(config_file_path, encoding="utf-8") as config_file:
-                return yaml.safe_load(config_file)
-        return None
-
-    @staticmethod
-    def _check_api_response(original_response: requests.Response):
-        response = original_response.json()
-        if "message" not in response:
-            raise RuntimeError("format error")
-        if response["message"] == "Unauthorized":
-            raise RuntimeError(
-                "Http 401 Error. User permission is denied due to invalid token.",
-                original_response.text,
-            )
-        return SwitchBotAPIResponse(response["statusCode"], response["message"], response["body"])
+    def devices(self) -> List[SwitchBotDevice]:
+        response = self.client.devices().body
+        devices = response["deviceList"]
+        devices.extend(response["infraredRemoteList"])
+        return [SwitchBotDeviceFactory.create(self.client, d) for d in devices]

--- a/switchbot_client/constants.py
+++ b/switchbot_client/constants.py
@@ -1,0 +1,2 @@
+class AppConstants:
+    VERSION = "0.1.2"

--- a/switchbot_client/constants.py
+++ b/switchbot_client/constants.py
@@ -1,2 +1,2 @@
 class AppConstants:
-    VERSION = "0.1.2"
+    VERSION = "0.2.0"

--- a/switchbot_client/devices/__init__.py
+++ b/switchbot_client/devices/__init__.py
@@ -2,3 +2,4 @@ from .base import *  # noqa
 from .factory import *  # noqa
 from .physical import *  # noqa
 from .remote import *  # noqa
+from .status import *  # noqa

--- a/switchbot_client/devices/__init__.py
+++ b/switchbot_client/devices/__init__.py
@@ -1,2 +1,4 @@
+from .base import *  # noqa
+from .factory import *  # noqa
 from .physical import *  # noqa
 from .remote import *  # noqa

--- a/switchbot_client/devices/__init__.py
+++ b/switchbot_client/devices/__init__.py
@@ -1,2 +1,2 @@
-from .physical import *
-from .remote import *
+from .physical import *  # noqa
+from .remote import *  # noqa

--- a/switchbot_client/devices/base.py
+++ b/switchbot_client/devices/base.py
@@ -1,28 +1,63 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from abc import ABC
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+from switchbot_client.devices.status import DeviceStatus
 
 if TYPE_CHECKING:
-    from switchbot_client.api import SwitchBotAPIClient, SwitchBotAPIResponse
+    from switchbot_client.api import SwitchBotAPIClient
 
 
-class SwitchBotDevice:
-    def __init__(self, client: SwitchBotAPIClient, device_id: str, device_type: str):
-        if client is None:
+@dataclass()
+class SwitchBotDevice(ABC):
+    client: SwitchBotAPIClient
+    device_id: str
+    device_type: str
+    device_name: str
+    hub_device_id: Optional[str]
+    is_virtual_infrared: bool
+
+    def __post_init__(self):
+        if self.client is None:
             raise TypeError
-        self.client = client
-        if device_id is None:
+        if self.device_id is None:
             raise TypeError
-        self.device_id = device_id
-        self.device_type = device_type
 
-    def status(self) -> SwitchBotAPIResponse:
-        return self.client.devices_status(self.device_id)
+        # SwitchBot API returns FFFFFFFFFFFF or 000000000000 if there is no hub device ID
+        if self.hub_device_id == "FFFFFFFFFFFF" or self.hub_device_id == "000000000000":
+            self.hub_device_id = None
 
-    def control(
+    def status(self) -> DeviceStatus:
+        status = self.client.devices_status(self.device_id).body
+        return DeviceStatus(
+            device_id=status["deviceId"] if "deviceId" in status else self.device_id,
+            device_type=status["deviceType"] if "deviceType" in status else self.device_type,
+            device_name=status["deviceName"] if "deviceName" in status else self.device_name,
+            hub_device_id=status["hubDeviceId"] if "hubDeviceId" in status else self.hub_device_id,
+            raw_data=status,
+        )
+
+    def command(
         self, command: str, parameter: str = None, command_type: str = None
-    ) -> SwitchBotAPIResponse:
-        return self.client.devices_commands(self.device_id, command, parameter, command_type)
+    ) -> SwitchBotCommandResult:
+        response = self.client.devices_commands(self.device_id, command, parameter, command_type)
+        return SwitchBotCommandResult(response.status_code, response.message, response.body)
 
     def __repr__(self):
-        return f"<{self.device_type},{self.device_id}>"
+        data = {
+            "device_id": self.device_id,
+            "device_type": self.device_type,
+            "device_name": self.device_name,
+            "hub_device_id": self.hub_device_id,
+            "is_virtual_infrared": self.is_virtual_infrared,
+        }
+        return self.__class__.__qualname__ + f"({data})"
+
+
+@dataclass()
+class SwitchBotCommandResult:
+    status_code: int
+    message: str
+    response_body: dict

--- a/switchbot_client/devices/base.py
+++ b/switchbot_client/devices/base.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from switchbot_client.api import SwitchBotAPIClient, SwitchBotAPIResponse
+
+
+class SwitchBotDevice:
+    def __init__(self, client: SwitchBotAPIClient, device_id: str, device_type: str):
+        if client is None:
+            raise TypeError
+        self.client = client
+        if device_id is None:
+            raise TypeError
+        self.device_id = device_id
+        self.device_type = device_type
+
+    def status(self) -> SwitchBotAPIResponse:
+        return self.client.devices_status(self.device_id)
+
+    def control(
+        self, command: str, parameter: str = None, command_type: str = None
+    ) -> SwitchBotAPIResponse:
+        return self.client.devices_commands(self.device_id, command, parameter, command_type)
+
+    def __repr__(self):
+        return f"<{self.device_type},{self.device_id}>"

--- a/switchbot_client/devices/base.py
+++ b/switchbot_client/devices/base.py
@@ -26,7 +26,7 @@ class SwitchBotDevice(ABC):
             raise TypeError
 
         # SwitchBot API returns FFFFFFFFFFFF or 000000000000 if there is no hub device ID
-        if self.hub_device_id == "FFFFFFFFFFFF" or self.hub_device_id == "000000000000":
+        if self.hub_device_id in ["FFFFFFFFFFFF", "000000000000"]:
             self.hub_device_id = None
 
     def status(self) -> DeviceStatus:

--- a/switchbot_client/devices/factory.py
+++ b/switchbot_client/devices/factory.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Union
+
+from .physical import SwitchBotPhysicalDevice
+from .remote import SwitchBotRemoteDevice
+
+if TYPE_CHECKING:
+    from switchbot_client.api import SwitchBotAPIClient
+    from switchbot_client.devices.base import SwitchBotDevice
+    from switchbot_client.types import APIPhysicalDeviceObject, APIRemoteDeviceObject
+
+
+class SwitchBotDeviceFactory:
+    @staticmethod
+    def create(
+        client: SwitchBotAPIClient, device: Union[APIPhysicalDeviceObject, APIRemoteDeviceObject]
+    ) -> SwitchBotDevice:
+        if "deviceType" in device:
+            return SwitchBotPhysicalDevice.create(client, device)  # type: ignore
+        if "remoteType" in device:
+            return SwitchBotRemoteDevice.create(client, device)  # type: ignore
+        raise TypeError(f"invalid device object: {device}")

--- a/switchbot_client/devices/factory.py
+++ b/switchbot_client/devices/factory.py
@@ -14,10 +14,11 @@ if TYPE_CHECKING:
 class SwitchBotDeviceFactory:
     @staticmethod
     def create(
-        client: SwitchBotAPIClient, device: Union[APIPhysicalDeviceObject, APIRemoteDeviceObject]
+        client: SwitchBotAPIClient,
+        api_object: Union[APIPhysicalDeviceObject, APIRemoteDeviceObject],
     ) -> SwitchBotDevice:
-        if "deviceType" in device:
-            return SwitchBotPhysicalDevice.create(client, device)  # type: ignore
-        if "remoteType" in device:
-            return SwitchBotRemoteDevice.create(client, device)  # type: ignore
-        raise TypeError(f"invalid device object: {device}")
+        if "deviceType" in api_object:
+            return SwitchBotPhysicalDevice.create_by_api_object(client, api_object)  # type: ignore
+        if "remoteType" in api_object:
+            return SwitchBotRemoteDevice.create_by_api_object(client, api_object)  # type: ignore
+        raise TypeError(f"invalid device object: {api_object}")

--- a/switchbot_client/devices/physical.py
+++ b/switchbot_client/devices/physical.py
@@ -111,6 +111,49 @@ class Meter(SwitchBotDevice):
         super().__init__(client, device_id, DeviceType.METER)
 
 
+class MotionSensor(SwitchBotDevice):
+    def __init__(self, client: SwitchBotAPIClient, device_id: str):
+        super().__init__(client, device_id, DeviceType.MOTION_SENSOR)
+
+
+class ContactSensor(SwitchBotDevice):
+    def __init__(self, client: SwitchBotAPIClient, device_id: str):
+        super().__init__(client, device_id, DeviceType.CONTACT_SENSOR)
+
+
+class ColorBulb(SwitchBotDevice):
+    def __init__(self, client: SwitchBotAPIClient, device_id: str):
+        super().__init__(client, device_id, DeviceType.COLOR_BULB)
+
+    def turn_on(self) -> SwitchBotAPIResponse:
+        return self.control(ControlCommand.Humidifier.TURN_ON)
+
+    def turn_off(self) -> SwitchBotAPIResponse:
+        return self.control(ControlCommand.Humidifier.TURN_OFF)
+
+    def set_brightness(self, brightness: int) -> SwitchBotAPIResponse:
+        """
+        brightness: 1 ~ 100
+        """
+        return self.control(ControlCommand.ColorBulb.SET_BRIGHTNESS, parameter=f"{brightness}")
+
+    def set_color(self, red: int, green: int, blue: int) -> SwitchBotAPIResponse:
+        """
+        red: 0 ~ 255
+        green: 0 ~ 255
+        blue: 0 ~ 255
+        """
+        return self.control(ControlCommand.ColorBulb.SET_COLOR, parameter=f"{red}:{green}:{blue}")
+
+    def set_color_temperature(self, temperature: int) -> SwitchBotAPIResponse:
+        """
+        temperature: 2700 ~ 6500
+        """
+        return self.control(
+            ControlCommand.ColorBulb.SET_COLOR_TEMPERATURE, parameter=f"{temperature}"
+        )
+
+
 class Humidifier(SwitchBotDevice):
     def __init__(self, client: SwitchBotAPIClient, device_id: str):
         super().__init__(client, device_id, DeviceType.HUMIDIFIER)

--- a/switchbot_client/devices/physical.py
+++ b/switchbot_client/devices/physical.py
@@ -5,105 +5,147 @@ from typing import TYPE_CHECKING
 from switchbot_client.enums import ControlCommand, DeviceType
 from switchbot_client.types import APIPhysicalDeviceObject
 
-from .base import SwitchBotDevice
+from .base import SwitchBotCommandResult, SwitchBotDevice
 
 if TYPE_CHECKING:
-    from switchbot_client.api import SwitchBotAPIClient, SwitchBotAPIResponse
+    from switchbot_client.api import SwitchBotAPIClient
 
 
 class SwitchBotPhysicalDevice(SwitchBotDevice):
-    def __init__(self, client: SwitchBotAPIClient, device_id: str, device_type: str):
-        super().__init__(client, device_id, device_type)
-        self._check_device_type()
+    def __init__(self, client: SwitchBotAPIClient, device: APIPhysicalDeviceObject):
+        device_id = device["deviceId"]
+        device_type = device["deviceType"]
+        device_name = device["deviceName"]
+        hub_device_id = device["hubDeviceId"]
+        super().__init__(client, device_id, device_type, device_name, hub_device_id, False)
+        self.device = device
 
     @staticmethod
-    def create(  # noqa
+    def create_by_api_object(  # noqa
         client: SwitchBotAPIClient, device: APIPhysicalDeviceObject
     ) -> SwitchBotPhysicalDevice:
         # pylint: disable=too-many-branches,too-many-return-statements
-        device_id = device["deviceId"]
         device_type = device["deviceType"]
         if device_type == DeviceType.HUB:
-            return Hub(client, device_id)
+            return Hub(client, device)
         if device_type == DeviceType.HUB_MINI:
-            return HubMini(client, device_id)
+            return HubMini(client, device)
         if device_type == DeviceType.HUB_PLUS:
-            return HubPlus(client, device_id)
+            return HubPlus(client, device)
         if device_type == DeviceType.BOT:
-            return Bot(client, device_id)
+            return Bot(client, device)
         if device_type == DeviceType.PLUG:
-            return Plug(client, device_id)
+            return Plug(client, device)
         if device_type == DeviceType.CURTAIN:
-            return Curtain(client, device_id)
+            return Curtain(client, device)
         if device_type == DeviceType.METER:
-            return Meter(client, device_id)
+            return Meter(client, device)
         if device_type == DeviceType.MOTION_SENSOR:
-            return MotionSensor(client, device_id)
+            return MotionSensor(client, device)
         if device_type == DeviceType.CONTACT_SENSOR:
-            return ContactSensor(client, device_id)
+            return ContactSensor(client, device)
         if device_type == DeviceType.COLOR_BULB:
-            return ColorBulb(client, device_id)
+            return ColorBulb(client, device)
         if device_type == DeviceType.HUMIDIFIER:
-            return Humidifier(client, device_id)
+            return Humidifier(client, device)
         if device_type == DeviceType.SMART_FAN:
-            return SmartFan(client, device_id)
+            return SmartFan(client, device)
         if device_type == DeviceType.INDOOR_CAM:
-            return IndoorCam(client, device_id)
+            return IndoorCam(client, device)
+        if device_type == DeviceType.REMOTE:
+            return Remote(client, device)
 
         raise TypeError(f"invalid physical device object: {device}")
 
-    def _check_device_type(self):
-        expected_device_type = self.device_type
-        status = self.client.devices_status(self.device_id)
-        # some device returns empty body for devices_status
-        if status.body == {}:
-            return
-        actual_device_type = status.body["deviceType"]
-        if actual_device_type != expected_device_type:
+    @staticmethod
+    def get_device_by_id(client: SwitchBotAPIClient, device_id: str) -> APIPhysicalDeviceObject:
+        if client is None:
+            raise TypeError
+        if device_id is None:
+            raise TypeError
+        response = client.devices()
+        physical_devices = response.body["deviceList"]
+        for device in physical_devices:
+            if device["deviceId"] == device_id:
+                return device
+        raise RuntimeError
+
+    def _check_device_type(self, expected_device_type: str):
+        if self.device_type != expected_device_type:
             raise RuntimeError(
                 f"Illegal device type. "
-                f"expected: {expected_device_type}, actual: {actual_device_type}"
+                f"expected: {expected_device_type}, actual: {self.device_type}"
             )
 
 
 class Hub(SwitchBotPhysicalDevice):
-    def __init__(self, client: SwitchBotAPIClient, device_id: str):
-        super().__init__(client, device_id, DeviceType.HUB)
+    def __init__(self, client: SwitchBotAPIClient, device: APIPhysicalDeviceObject):
+        super().__init__(client, device)
+        self._check_device_type(DeviceType.HUB)
+
+    @staticmethod
+    def create_by_id(client: SwitchBotAPIClient, device_id: str) -> Hub:
+        device = SwitchBotPhysicalDevice.get_device_by_id(client, device_id)
+        return Hub(client, device)
 
 
 class HubMini(SwitchBotPhysicalDevice):
-    def __init__(self, client: SwitchBotAPIClient, device_id: str):
-        super().__init__(client, device_id, DeviceType.HUB_MINI)
+    def __init__(self, client: SwitchBotAPIClient, device: APIPhysicalDeviceObject):
+        super().__init__(client, device)
+        self._check_device_type(DeviceType.HUB_MINI)
+
+    @staticmethod
+    def create_by_id(client: SwitchBotAPIClient, device_id: str) -> HubMini:
+        device = SwitchBotPhysicalDevice.get_device_by_id(client, device_id)
+        return HubMini(client, device)
 
 
 class HubPlus(SwitchBotPhysicalDevice):
-    def __init__(self, client: SwitchBotAPIClient, device_id: str):
-        super().__init__(client, device_id, DeviceType.HUB_PLUS)
+    def __init__(self, client: SwitchBotAPIClient, device: APIPhysicalDeviceObject):
+        super().__init__(client, device)
+        self._check_device_type(DeviceType.HUB_PLUS)
+
+    @staticmethod
+    def create_by_id(client: SwitchBotAPIClient, device_id: str) -> HubPlus:
+        device = SwitchBotPhysicalDevice.get_device_by_id(client, device_id)
+        return HubPlus(client, device)
 
 
 class Bot(SwitchBotPhysicalDevice):
-    def __init__(self, client: SwitchBotAPIClient, device_id: str):
-        super().__init__(client, device_id, DeviceType.BOT)
+    def __init__(self, client: SwitchBotAPIClient, device: APIPhysicalDeviceObject):
+        super().__init__(client, device)
+        self._check_device_type(DeviceType.BOT)
 
-    def turn_on(self) -> SwitchBotAPIResponse:
-        return self.control(ControlCommand.Bot.TURN_ON)
+    @staticmethod
+    def create_by_id(client: SwitchBotAPIClient, device_id: str) -> Bot:
+        device = SwitchBotPhysicalDevice.get_device_by_id(client, device_id)
+        return Bot(client, device)
 
-    def turn_off(self) -> SwitchBotAPIResponse:
-        return self.control(ControlCommand.Bot.TURN_OFF)
+    def turn_on(self) -> SwitchBotCommandResult:
+        return self.command(ControlCommand.Bot.TURN_ON)
 
-    def press(self) -> SwitchBotAPIResponse:
-        return self.control(ControlCommand.Bot.PRESS)
+    def turn_off(self) -> SwitchBotCommandResult:
+        return self.command(ControlCommand.Bot.TURN_OFF)
+
+    def press(self) -> SwitchBotCommandResult:
+        return self.command(ControlCommand.Bot.PRESS)
 
 
 class Plug(SwitchBotPhysicalDevice):
-    def __init__(self, client: SwitchBotAPIClient, device_id: str):
-        super().__init__(client, device_id, DeviceType.PLUG)
+    def __init__(self, client: SwitchBotAPIClient, device: APIPhysicalDeviceObject):
+        super().__init__(client, device)
+        self._check_device_type(DeviceType.PLUG)
 
-    def turn_on(self) -> SwitchBotAPIResponse:
-        return self.control(ControlCommand.Plug.TURN_ON)
+    @staticmethod
+    def create_by_id(client: SwitchBotAPIClient, device_id: str) -> Plug:
+        device = SwitchBotPhysicalDevice.get_device_by_id(client, device_id)
+        return Plug(client, device)
 
-    def turn_off(self) -> SwitchBotAPIResponse:
-        return self.control(ControlCommand.Plug.TURN_OFF)
+    def turn_on(self) -> SwitchBotCommandResult:
+        return self.command(ControlCommand.Plug.TURN_ON)
+
+    def turn_off(self) -> SwitchBotCommandResult:
+        return self.command(ControlCommand.Plug.TURN_OFF)
 
 
 class Curtain(SwitchBotPhysicalDevice):
@@ -112,84 +154,130 @@ class Curtain(SwitchBotPhysicalDevice):
         MODE_SILENT = "1"
         MODE_DEFAULT = "ff"
 
-    def __init__(self, client: SwitchBotAPIClient, device_id: str):
-        super().__init__(client, device_id, DeviceType.CURTAIN)
+    def __init__(self, client: SwitchBotAPIClient, device: APIPhysicalDeviceObject):
+        super().__init__(client, device)
+        self._check_device_type(DeviceType.CURTAIN)
 
-    def turn_on(self) -> SwitchBotAPIResponse:
-        return self.control(ControlCommand.Curtain.TURN_ON)
+    @staticmethod
+    def create_by_id(client: SwitchBotAPIClient, device_id: str) -> Curtain:
+        device = SwitchBotPhysicalDevice.get_device_by_id(client, device_id)
+        return Curtain(client, device)
 
-    def turn_off(self) -> SwitchBotAPIResponse:
-        return self.control(ControlCommand.Curtain.TURN_OFF)
+    def turn_on(self) -> SwitchBotCommandResult:
+        return self.command(ControlCommand.Curtain.TURN_ON)
 
-    def set_position(self, index: int, mode: str, position: int) -> SwitchBotAPIResponse:
+    def turn_off(self) -> SwitchBotCommandResult:
+        return self.command(ControlCommand.Curtain.TURN_OFF)
+
+    def set_position(self, index: int, mode: str, position: int) -> SwitchBotCommandResult:
         """
         mode(Parameters.MODE_XXX): 0 (Performance Mode), 1 (Silent Mode), ff (default mode)
         position: 0 ~ 100 (0 means opened, 100 means closed)
         """
-        return self.control(
+        return self.command(
             ControlCommand.Curtain.SET_POSITION, parameter=f"{index},{mode},{position}"
         )
 
 
 class Meter(SwitchBotPhysicalDevice):
-    def __init__(self, client: SwitchBotAPIClient, device_id: str):
-        super().__init__(client, device_id, DeviceType.METER)
+    def __init__(self, client: SwitchBotAPIClient, device: APIPhysicalDeviceObject):
+        super().__init__(client, device)
+        self._check_device_type(DeviceType.METER)
+
+    @staticmethod
+    def create_by_id(client: SwitchBotAPIClient, device_id: str) -> Meter:
+        device = SwitchBotPhysicalDevice.get_device_by_id(client, device_id)
+        return Meter(client, device)
+
+    def temperature(self) -> float:
+        return float(self.status().raw_data["temperature"])
+
+    def humidity(self) -> float:
+        return float(self.status().raw_data["humidity"])
 
 
 class MotionSensor(SwitchBotPhysicalDevice):
-    def __init__(self, client: SwitchBotAPIClient, device_id: str):
-        super().__init__(client, device_id, DeviceType.MOTION_SENSOR)
+    def __init__(self, client: SwitchBotAPIClient, device: APIPhysicalDeviceObject):
+        super().__init__(client, device)
+        self._check_device_type(DeviceType.MOTION_SENSOR)
+
+    @staticmethod
+    def create_by_id(client: SwitchBotAPIClient, device_id: str) -> MotionSensor:
+        device = SwitchBotPhysicalDevice.get_device_by_id(client, device_id)
+        return MotionSensor(client, device)
 
 
 class ContactSensor(SwitchBotPhysicalDevice):
-    def __init__(self, client: SwitchBotAPIClient, device_id: str):
-        super().__init__(client, device_id, DeviceType.CONTACT_SENSOR)
+    def __init__(self, client: SwitchBotAPIClient, device: APIPhysicalDeviceObject):
+        super().__init__(client, device)
+        self._check_device_type(DeviceType.CONTACT_SENSOR)
+
+    @staticmethod
+    def create_by_id(client: SwitchBotAPIClient, device_id: str) -> ContactSensor:
+        device = SwitchBotPhysicalDevice.get_device_by_id(client, device_id)
+        return ContactSensor(client, device)
 
 
 class ColorBulb(SwitchBotPhysicalDevice):
-    def __init__(self, client: SwitchBotAPIClient, device_id: str):
-        super().__init__(client, device_id, DeviceType.COLOR_BULB)
+    def __init__(self, client: SwitchBotAPIClient, device: APIPhysicalDeviceObject):
+        super().__init__(client, device)
+        self._check_device_type(DeviceType.COLOR_BULB)
 
-    def turn_on(self) -> SwitchBotAPIResponse:
-        return self.control(ControlCommand.Humidifier.TURN_ON)
+    @staticmethod
+    def create_by_id(client: SwitchBotAPIClient, device_id: str) -> ColorBulb:
+        device = SwitchBotPhysicalDevice.get_device_by_id(client, device_id)
+        return ColorBulb(client, device)
 
-    def turn_off(self) -> SwitchBotAPIResponse:
-        return self.control(ControlCommand.Humidifier.TURN_OFF)
+    def turn_on(self) -> SwitchBotCommandResult:
+        return self.command(ControlCommand.Humidifier.TURN_ON)
 
-    def set_brightness(self, brightness: int) -> SwitchBotAPIResponse:
+    def turn_off(self) -> SwitchBotCommandResult:
+        return self.command(ControlCommand.Humidifier.TURN_OFF)
+
+    def set_brightness(self, brightness: int) -> SwitchBotCommandResult:
         """
         brightness: 1 ~ 100
         """
-        return self.control(ControlCommand.ColorBulb.SET_BRIGHTNESS, parameter=f"{brightness}")
+        return self.command(ControlCommand.ColorBulb.SET_BRIGHTNESS, parameter=f"{brightness}")
 
-    def set_color(self, red: int, green: int, blue: int) -> SwitchBotAPIResponse:
+    def set_color_by_number(self, red: int, green: int, blue: int) -> SwitchBotCommandResult:
         """
         red: 0 ~ 255
         green: 0 ~ 255
         blue: 0 ~ 255
         """
-        return self.control(ControlCommand.ColorBulb.SET_COLOR, parameter=f"{red}:{green}:{blue}")
+        return self.command(ControlCommand.ColorBulb.SET_COLOR, parameter=f"{red}:{green}:{blue}")
 
-    def set_color_temperature(self, temperature: int) -> SwitchBotAPIResponse:
+    def set_color(self, color_hex: str) -> SwitchBotCommandResult:
+        rgb = tuple(int(color_hex.lstrip("#")[i : i + 2], 16) for i in (0, 2, 4))
+        return self.set_color_by_number(rgb[0], rgb[1], rgb[2])
+
+    def set_color_temperature(self, temperature: int) -> SwitchBotCommandResult:
         """
         temperature: 2700 ~ 6500
         """
-        return self.control(
+        return self.command(
             ControlCommand.ColorBulb.SET_COLOR_TEMPERATURE, parameter=f"{temperature}"
         )
 
 
 class Humidifier(SwitchBotPhysicalDevice):
-    def __init__(self, client: SwitchBotAPIClient, device_id: str):
-        super().__init__(client, device_id, DeviceType.HUMIDIFIER)
+    def __init__(self, client: SwitchBotAPIClient, device: APIPhysicalDeviceObject):
+        super().__init__(client, device)
+        self._check_device_type(DeviceType.HUMIDIFIER)
 
-    def turn_on(self) -> SwitchBotAPIResponse:
-        return self.control(ControlCommand.Humidifier.TURN_ON)
+    @staticmethod
+    def create_by_id(client: SwitchBotAPIClient, device_id: str) -> Humidifier:
+        device = SwitchBotPhysicalDevice.get_device_by_id(client, device_id)
+        return Humidifier(client, device)
 
-    def turn_off(self) -> SwitchBotAPIResponse:
-        return self.control(ControlCommand.Humidifier.TURN_OFF)
+    def turn_on(self) -> SwitchBotCommandResult:
+        return self.command(ControlCommand.Humidifier.TURN_ON)
 
-    def set_mode(self, mode: str) -> SwitchBotAPIResponse:
+    def turn_off(self) -> SwitchBotCommandResult:
+        return self.command(ControlCommand.Humidifier.TURN_OFF)
+
+    def set_mode(self, mode: str) -> SwitchBotCommandResult:
         """
         auto or 101 or 102 or 103 or {0~100}
         auto: set to Auto Mode
@@ -197,7 +285,7 @@ class Humidifier(SwitchBotPhysicalDevice):
         102: set atomization efficiency to 67%
         103: set atomization efficiency to 100%
         """
-        return self.control(ControlCommand.Humidifier.SET_MODE, parameter=mode)
+        return self.command(ControlCommand.Humidifier.SET_MODE, parameter=mode)
 
 
 class SmartFan(SwitchBotPhysicalDevice):
@@ -207,30 +295,53 @@ class SmartFan(SwitchBotPhysicalDevice):
         FAN_MODE_STANDARD = 1
         FAN_MODE_NATURAL = 2
 
-    def __init__(self, client: SwitchBotAPIClient, device_id: str):
-        super().__init__(client, device_id, DeviceType.SMART_FAN)
+    def __init__(self, client: SwitchBotAPIClient, device: APIPhysicalDeviceObject):
+        super().__init__(client, device)
+        self._check_device_type(DeviceType.SMART_FAN)
 
-    def turn_on(self) -> SwitchBotAPIResponse:
-        return self.control(ControlCommand.SmartFan.TURN_ON)
+    @staticmethod
+    def create_by_id(client: SwitchBotAPIClient, device_id: str) -> SmartFan:
+        device = SwitchBotPhysicalDevice.get_device_by_id(client, device_id)
+        return SmartFan(client, device)
 
-    def turn_off(self) -> SwitchBotAPIResponse:
-        return self.control(ControlCommand.SmartFan.TURN_OFF)
+    def turn_on(self) -> SwitchBotCommandResult:
+        return self.command(ControlCommand.SmartFan.TURN_ON)
+
+    def turn_off(self) -> SwitchBotCommandResult:
+        return self.command(ControlCommand.SmartFan.TURN_OFF)
 
     def set_all_status(
         self, power: str, fan_mode: int, fan_speed: int, shake_range: int
-    ) -> SwitchBotAPIResponse:
+    ) -> SwitchBotCommandResult:
         """
         power(Parameters.POWER_XXX): off, on
         fan_mode(Parameters.FAN_MODE_XXX): 1 (Standard), 2 (Natural)
         fan_speed: 1, 2, 3, 4
         shake_range: 0 ~ 120
         """
-        return self.control(
+        return self.command(
             ControlCommand.SmartFan.SET_ALL_STATUS,
             parameter=f"{power},{fan_mode},{fan_speed},{shake_range}",
         )
 
 
 class IndoorCam(SwitchBotPhysicalDevice):
-    def __init__(self, client: SwitchBotAPIClient, device_id: str):
-        super().__init__(client, device_id, DeviceType.INDOOR_CAM)
+    def __init__(self, client: SwitchBotAPIClient, device: APIPhysicalDeviceObject):
+        super().__init__(client, device)
+        self._check_device_type(DeviceType.INDOOR_CAM)
+
+    @staticmethod
+    def create_by_id(client: SwitchBotAPIClient, device_id: str) -> IndoorCam:
+        device = SwitchBotPhysicalDevice.get_device_by_id(client, device_id)
+        return IndoorCam(client, device)
+
+
+class Remote(SwitchBotPhysicalDevice):
+    def __init__(self, client: SwitchBotAPIClient, device: APIPhysicalDeviceObject):
+        super().__init__(client, device)
+        self._check_device_type(DeviceType.REMOTE)
+
+    @staticmethod
+    def create_by_id(client: SwitchBotAPIClient, device_id: str) -> Remote:
+        device = SwitchBotPhysicalDevice.get_device_by_id(client, device_id)
+        return Remote(client, device)

--- a/switchbot_client/devices/remote.py
+++ b/switchbot_client/devices/remote.py
@@ -5,74 +5,83 @@ from typing import TYPE_CHECKING
 from switchbot_client.enums import ControlCommand, RemoteType
 from switchbot_client.types import APIRemoteDeviceObject
 
-from .base import SwitchBotDevice
+from .base import SwitchBotCommandResult, SwitchBotDevice
 
 if TYPE_CHECKING:
-    from switchbot_client.api import SwitchBotAPIClient, SwitchBotAPIResponse
+    from switchbot_client.api import SwitchBotAPIClient
 
 
 class SwitchBotRemoteDevice(SwitchBotDevice):
-    def __init__(self, client: SwitchBotAPIClient, device_id: str, device_type: str):
-        super().__init__(client, device_id, device_type)
-        self._check_remote_type()
+    def __init__(self, client: SwitchBotAPIClient, device: APIRemoteDeviceObject):
+        device_id = device["deviceId"]
+        remote_type = device["remoteType"]
+        device_name = device["deviceName"]
+        hub_device_id = device["hubDeviceId"]
+        super().__init__(client, device_id, remote_type, device_name, hub_device_id, True)
+        self.device = device
 
-    def turn_on(self) -> SwitchBotAPIResponse:
-        return self.control(ControlCommand.VirtualInfrared.TURN_ON)
+    def turn_on(self) -> SwitchBotCommandResult:
+        return self.command(ControlCommand.VirtualInfrared.TURN_ON)
 
-    def turn_off(self) -> SwitchBotAPIResponse:
-        return self.control(ControlCommand.VirtualInfrared.TURN_OFF)
+    def turn_off(self) -> SwitchBotCommandResult:
+        return self.command(ControlCommand.VirtualInfrared.TURN_OFF)
 
     @staticmethod
-    def create(  # noqa
+    def create_by_api_object(  # noqa
         client: SwitchBotAPIClient, device: APIRemoteDeviceObject
     ) -> SwitchBotRemoteDevice:
         # pylint: disable=too-many-branches,too-many-return-statements
-        device_id = device["deviceId"]
         remote_type = device["remoteType"]
         if remote_type == RemoteType.AIR_CONDITIONER:
-            return AirConditioner(client, device_id)
+            return AirConditioner(client, device)
         if remote_type == RemoteType.TV:
-            return TV(client, device_id)
+            return TV(client, device)
         if remote_type == RemoteType.LIGHT:
-            return Light(client, device_id)
+            return Light(client, device)
         if remote_type == RemoteType.IPTV_STREAMER:
-            return IPTVStreamer(client, device_id)
+            return IPTVStreamer(client, device)
         if remote_type == RemoteType.SET_TOP_BOX:
-            return SetTopBox(client, device_id)
+            return SetTopBox(client, device)
         if remote_type == RemoteType.DVD:
-            return DVD(client, device_id)
+            return DVD(client, device)
         if remote_type == RemoteType.FAN:
-            return Fan(client, device_id)
+            return Fan(client, device)
         if remote_type == RemoteType.PROJECTOR:
-            return Projector(client, device_id)
+            return Projector(client, device)
         if remote_type == RemoteType.CAMERA:
-            return Camera(client, device_id)
+            return Camera(client, device)
         if remote_type == RemoteType.AIR_PURIFIER:
-            return AirPurifier(client, device_id)
+            return AirPurifier(client, device)
         if remote_type == RemoteType.SPEAKER:
-            return Speaker(client, device_id)
+            return Speaker(client, device)
         if remote_type == RemoteType.WATER_HEATER:
-            return WaterHeater(client, device_id)
+            return WaterHeater(client, device)
         if remote_type == RemoteType.VACUUM_CLEANER:
-            return VacuumCleaner(client, device_id)
+            return VacuumCleaner(client, device)
         if remote_type == RemoteType.OTHERS:
-            return Others(client, device_id)
+            return Others(client, device)
 
         raise TypeError(f"invalid physical device object: {device}")
 
-    def _check_remote_type(self):
-        expected_device_type = self.device_type
-        infrared_remote_devices = self.client.devices().body["infraredRemoteList"]
-        for device in infrared_remote_devices:
-            if device["deviceId"] == self.device_id:
-                actual_device_type = device["remoteType"]
-                if actual_device_type == expected_device_type:
-                    return
-                raise RuntimeError(
-                    f"Illegal device type. "
-                    f"expected: {expected_device_type}, actual: {actual_device_type}"
-                )
-        raise RuntimeError(f"device not found: {self.device_id}")
+    @staticmethod
+    def get_device_by_id(client: SwitchBotAPIClient, device_id: str) -> APIRemoteDeviceObject:
+        if client is None:
+            raise TypeError
+        if device_id is None:
+            raise TypeError
+        response = client.devices()
+        remote_devices = response.body["infraredRemoteList"]
+        for device in remote_devices:
+            if device["deviceId"] == device_id:
+                return device
+        raise RuntimeError
+
+    def _check_remote_type(self, expected_device_type: str):
+        if self.device_type != expected_device_type:
+            raise RuntimeError(
+                f"Illegal device type. "
+                f"expected: {expected_device_type}, actual: {self.device_type}"
+            )
 
 
 class AirConditioner(SwitchBotRemoteDevice):
@@ -89,90 +98,174 @@ class AirConditioner(SwitchBotRemoteDevice):
         POWER_ON = "on"
         POWER_OFF = "off"
 
-    def __init__(self, client: SwitchBotAPIClient, device_id: str):
-        super().__init__(client, device_id, RemoteType.AIR_CONDITIONER)
+    def __init__(self, client: SwitchBotAPIClient, device: APIRemoteDeviceObject):
+        super().__init__(client, device)
+        self._check_remote_type(RemoteType.AIR_CONDITIONER)
 
     def set_all(
-        self, temperature: int, mode: str, fan_speed: str, power: str
-    ) -> SwitchBotAPIResponse:
+        self, temperature: float, mode: str, fan_speed: str, power: str
+    ) -> SwitchBotCommandResult:
         """
         temperature: temperature in celsius
         mode(Parameters.MODE_XXX): 1(auto), 2(cool), 3(dry), 4(fan), 5(heat)
         fan_speed(Parameters.FAN_SPEED_XXX): 1(auto), 2(low), 3(medium), 4(high);
         power(Parameters.POWER_XXX): on, off
         """
-        return self.control(
+        return self.command(
             ControlCommand.VirtualInfrared.SET_ALL,
             parameter=f"{temperature},{mode},{fan_speed},{power}",
         )
 
+    @staticmethod
+    def create_by_id(client: SwitchBotAPIClient, device_id: str) -> AirConditioner:
+        device = SwitchBotRemoteDevice.get_device_by_id(client, device_id)
+        return AirConditioner(client, device)
+
 
 class TV(SwitchBotRemoteDevice):
-    def __init__(self, client: SwitchBotAPIClient, device_id: str):
-        super().__init__(client, device_id, RemoteType.TV)
+    def __init__(self, client: SwitchBotAPIClient, device: APIRemoteDeviceObject):
+        super().__init__(client, device)
+        self._check_remote_type(RemoteType.TV)
+
+    @staticmethod
+    def create_by_id(client: SwitchBotAPIClient, device_id: str) -> TV:
+        device = SwitchBotRemoteDevice.get_device_by_id(client, device_id)
+        return TV(client, device)
 
 
 class Light(SwitchBotRemoteDevice):
-    def __init__(self, client: SwitchBotAPIClient, device_id: str):
-        super().__init__(client, device_id, RemoteType.LIGHT)
+    def __init__(self, client: SwitchBotAPIClient, device: APIRemoteDeviceObject):
+        super().__init__(client, device)
+        self._check_remote_type(RemoteType.LIGHT)
 
-    def brightness_up(self) -> SwitchBotAPIResponse:
-        return self.control(ControlCommand.VirtualInfrared.BRIGHTNESS_UP)
+    def brightness_up(self) -> SwitchBotCommandResult:
+        return self.command(ControlCommand.VirtualInfrared.BRIGHTNESS_UP)
 
-    def brightness_down(self) -> SwitchBotAPIResponse:
-        return self.control(ControlCommand.VirtualInfrared.BRIGHTNESS_DOWN)
+    def brightness_down(self) -> SwitchBotCommandResult:
+        return self.command(ControlCommand.VirtualInfrared.BRIGHTNESS_DOWN)
+
+    @staticmethod
+    def create_by_id(client: SwitchBotAPIClient, device_id: str) -> Light:
+        device = SwitchBotRemoteDevice.get_device_by_id(client, device_id)
+        return Light(client, device)
 
 
 class IPTVStreamer(SwitchBotRemoteDevice):
-    def __init__(self, client: SwitchBotAPIClient, device_id: str):
-        super().__init__(client, device_id, RemoteType.IPTV_STREAMER)
+    def __init__(self, client: SwitchBotAPIClient, device: APIRemoteDeviceObject):
+        super().__init__(client, device)
+        self._check_remote_type(RemoteType.IPTV_STREAMER)
+
+    @staticmethod
+    def create_by_id(client: SwitchBotAPIClient, device_id: str) -> IPTVStreamer:
+        device = SwitchBotRemoteDevice.get_device_by_id(client, device_id)
+        return IPTVStreamer(client, device)
 
 
 class SetTopBox(SwitchBotRemoteDevice):
-    def __init__(self, client: SwitchBotAPIClient, device_id: str):
-        super().__init__(client, device_id, RemoteType.SET_TOP_BOX)
+    def __init__(self, client: SwitchBotAPIClient, device: APIRemoteDeviceObject):
+        super().__init__(client, device)
+        self._check_remote_type(RemoteType.SET_TOP_BOX)
+
+    @staticmethod
+    def create_by_id(client: SwitchBotAPIClient, device_id: str) -> SetTopBox:
+        device = SwitchBotRemoteDevice.get_device_by_id(client, device_id)
+        return SetTopBox(client, device)
 
 
 class DVD(SwitchBotRemoteDevice):
-    def __init__(self, client: SwitchBotAPIClient, device_id: str):
-        super().__init__(client, device_id, RemoteType.DVD)
+    def __init__(self, client: SwitchBotAPIClient, device: APIRemoteDeviceObject):
+        super().__init__(client, device)
+        self._check_remote_type(RemoteType.DVD)
+
+    @staticmethod
+    def create_by_id(client: SwitchBotAPIClient, device_id: str) -> DVD:
+        device = SwitchBotRemoteDevice.get_device_by_id(client, device_id)
+        return DVD(client, device)
 
 
 class Fan(SwitchBotRemoteDevice):
-    def __init__(self, client: SwitchBotAPIClient, device_id: str):
-        super().__init__(client, device_id, RemoteType.FAN)
+    def __init__(self, client: SwitchBotAPIClient, device: APIRemoteDeviceObject):
+        super().__init__(client, device)
+        self._check_remote_type(RemoteType.FAN)
+
+    @staticmethod
+    def create_by_id(client: SwitchBotAPIClient, device_id: str) -> Fan:
+        device = SwitchBotRemoteDevice.get_device_by_id(client, device_id)
+        return Fan(client, device)
 
 
 class Projector(SwitchBotRemoteDevice):
-    def __init__(self, client: SwitchBotAPIClient, device_id: str):
-        super().__init__(client, device_id, RemoteType.PROJECTOR)
+    def __init__(self, client: SwitchBotAPIClient, device: APIRemoteDeviceObject):
+        super().__init__(client, device)
+        self._check_remote_type(RemoteType.PROJECTOR)
+
+    @staticmethod
+    def create_by_id(client: SwitchBotAPIClient, device_id: str) -> Projector:
+        device = SwitchBotRemoteDevice.get_device_by_id(client, device_id)
+        return Projector(client, device)
 
 
 class Camera(SwitchBotRemoteDevice):
-    def __init__(self, client: SwitchBotAPIClient, device_id: str):
-        super().__init__(client, device_id, RemoteType.CAMERA)
+    def __init__(self, client: SwitchBotAPIClient, device: APIRemoteDeviceObject):
+        super().__init__(client, device)
+        self._check_remote_type(RemoteType.CAMERA)
+
+    @staticmethod
+    def create_by_id(client: SwitchBotAPIClient, device_id: str) -> Camera:
+        device = SwitchBotRemoteDevice.get_device_by_id(client, device_id)
+        return Camera(client, device)
 
 
 class AirPurifier(SwitchBotRemoteDevice):
-    def __init__(self, client: SwitchBotAPIClient, device_id: str):
-        super().__init__(client, device_id, RemoteType.AIR_PURIFIER)
+    def __init__(self, client: SwitchBotAPIClient, device: APIRemoteDeviceObject):
+        super().__init__(client, device)
+        self._check_remote_type(RemoteType.AIR_PURIFIER)
+
+    @staticmethod
+    def create_by_id(client: SwitchBotAPIClient, device_id: str) -> AirPurifier:
+        device = SwitchBotRemoteDevice.get_device_by_id(client, device_id)
+        return AirPurifier(client, device)
 
 
 class Speaker(SwitchBotRemoteDevice):
-    def __init__(self, client: SwitchBotAPIClient, device_id: str):
-        super().__init__(client, device_id, RemoteType.SPEAKER)
+    def __init__(self, client: SwitchBotAPIClient, device: APIRemoteDeviceObject):
+        super().__init__(client, device)
+        self._check_remote_type(RemoteType.SPEAKER)
+
+    @staticmethod
+    def create_by_id(client: SwitchBotAPIClient, device_id: str) -> Speaker:
+        device = SwitchBotRemoteDevice.get_device_by_id(client, device_id)
+        return Speaker(client, device)
 
 
 class WaterHeater(SwitchBotRemoteDevice):
-    def __init__(self, client: SwitchBotAPIClient, device_id: str):
-        super().__init__(client, device_id, RemoteType.WATER_HEATER)
+    def __init__(self, client: SwitchBotAPIClient, device: APIRemoteDeviceObject):
+        super().__init__(client, device)
+        self._check_remote_type(RemoteType.WATER_HEATER)
+
+    @staticmethod
+    def create_by_id(client: SwitchBotAPIClient, device_id: str) -> WaterHeater:
+        device = SwitchBotRemoteDevice.get_device_by_id(client, device_id)
+        return WaterHeater(client, device)
 
 
 class VacuumCleaner(SwitchBotRemoteDevice):
-    def __init__(self, client: SwitchBotAPIClient, device_id: str):
-        super().__init__(client, device_id, RemoteType.VACUUM_CLEANER)
+    def __init__(self, client: SwitchBotAPIClient, device: APIRemoteDeviceObject):
+        super().__init__(client, device)
+        self._check_remote_type(RemoteType.VACUUM_CLEANER)
+
+    @staticmethod
+    def create_by_id(client: SwitchBotAPIClient, device_id: str) -> VacuumCleaner:
+        device = SwitchBotRemoteDevice.get_device_by_id(client, device_id)
+        return VacuumCleaner(client, device)
 
 
 class Others(SwitchBotRemoteDevice):
-    def __init__(self, client: SwitchBotAPIClient, device_id: str):
-        super().__init__(client, device_id, RemoteType.OTHERS)
+    def __init__(self, client: SwitchBotAPIClient, device: APIRemoteDeviceObject):
+        super().__init__(client, device)
+        self._check_remote_type(RemoteType.OTHERS)
+
+    @staticmethod
+    def create_by_id(client: SwitchBotAPIClient, device_id: str) -> Others:
+        device = SwitchBotRemoteDevice.get_device_by_id(client, device_id)
+        return Others(client, device)

--- a/switchbot_client/devices/remote.py
+++ b/switchbot_client/devices/remote.py
@@ -1,13 +1,17 @@
-from switchbot_client import (
-    SwitchBotAPIClient,
-    SwitchBotAPIResponse,
-    RemoteType,
-    ControlCommand,
-)
-from .physical import SwitchBotDeviceBase
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from switchbot_client.enums import ControlCommand, RemoteType
+from switchbot_client.types import APIRemoteDeviceObject
+
+from .base import SwitchBotDevice
+
+if TYPE_CHECKING:
+    from switchbot_client.api import SwitchBotAPIClient, SwitchBotAPIResponse
 
 
-class SwitchBotRemoteDevice(SwitchBotDeviceBase):
+class SwitchBotRemoteDevice(SwitchBotDevice):
     def __init__(self, client: SwitchBotAPIClient, device_id: str, device_type: str):
         super().__init__(client, device_id, device_type)
         self._check_remote_type()
@@ -17,6 +21,44 @@ class SwitchBotRemoteDevice(SwitchBotDeviceBase):
 
     def turn_off(self) -> SwitchBotAPIResponse:
         return self.control(ControlCommand.VirtualInfrared.TURN_OFF)
+
+    @staticmethod
+    def create(  # noqa
+        client: SwitchBotAPIClient, device: APIRemoteDeviceObject
+    ) -> SwitchBotRemoteDevice:
+        # pylint: disable=too-many-branches,too-many-return-statements
+        device_id = device["deviceId"]
+        remote_type = device["remoteType"]
+        if remote_type == RemoteType.AIR_CONDITIONER:
+            return AirConditioner(client, device_id)
+        if remote_type == RemoteType.TV:
+            return TV(client, device_id)
+        if remote_type == RemoteType.LIGHT:
+            return Light(client, device_id)
+        if remote_type == RemoteType.IPTV_STREAMER:
+            return IPTVStreamer(client, device_id)
+        if remote_type == RemoteType.SET_TOP_BOX:
+            return SetTopBox(client, device_id)
+        if remote_type == RemoteType.DVD:
+            return DVD(client, device_id)
+        if remote_type == RemoteType.FAN:
+            return Fan(client, device_id)
+        if remote_type == RemoteType.PROJECTOR:
+            return Projector(client, device_id)
+        if remote_type == RemoteType.CAMERA:
+            return Camera(client, device_id)
+        if remote_type == RemoteType.AIR_PURIFIER:
+            return AirPurifier(client, device_id)
+        if remote_type == RemoteType.SPEAKER:
+            return Speaker(client, device_id)
+        if remote_type == RemoteType.WATER_HEATER:
+            return WaterHeater(client, device_id)
+        if remote_type == RemoteType.VACUUM_CLEANER:
+            return VacuumCleaner(client, device_id)
+        if remote_type == RemoteType.OTHERS:
+            return Others(client, device_id)
+
+        raise TypeError(f"invalid physical device object: {device}")
 
     def _check_remote_type(self):
         expected_device_type = self.device_type

--- a/switchbot_client/devices/status.py
+++ b/switchbot_client/devices/status.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+
+@dataclass()
+class DeviceStatus:
+    device_id: str
+    device_type: str
+    device_name: str
+    hub_device_id: str
+    raw_data: dict

--- a/switchbot_client/enums.py
+++ b/switchbot_client/enums.py
@@ -6,6 +6,9 @@ class DeviceType:
     CURTAIN = "Curtain"
     PLUG = "Plug"
     METER = "Meter"
+    MOTION_SENSOR = "Motion Sensor"
+    CONTACT_SENSOR = "Contact Sensor"
+    COLOR_BULB = "Color Bulb"
     HUMIDIFIER = "Humidifier"
     SMART_FAN = "Smart Fan"
     INDOOR_CAM = "Indoor Cam"
@@ -47,6 +50,14 @@ class ControlCommand:
         TURN_ON = "turnOn"
         TURN_OFF = "turnOff"
         SET_MODE = "setMode"
+
+    class ColorBulb:
+        TURN_ON = "turnOn"
+        TURN_OFF = "turnOff"
+        TOGGLE = "toggle"
+        SET_BRIGHTNESS = "setBrightness"
+        SET_COLOR = "setColor"
+        SET_COLOR_TEMPERATURE = "setColorTemperature"
 
     class SmartFan:
         TURN_ON = "turnOn"

--- a/switchbot_client/enums.py
+++ b/switchbot_client/enums.py
@@ -12,6 +12,7 @@ class DeviceType:
     HUMIDIFIER = "Humidifier"
     SMART_FAN = "Smart Fan"
     INDOOR_CAM = "Indoor Cam"
+    REMOTE = "Remote"  # undocumented in official api reference?
 
 
 class RemoteType:

--- a/switchbot_client/scenes/__init__.py
+++ b/switchbot_client/scenes/__init__.py
@@ -1,0 +1,1 @@
+from .base import *  # noqa

--- a/switchbot_client/scenes/base.py
+++ b/switchbot_client/scenes/base.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from switchbot_client.devices import SwitchBotCommandResult
+
+if TYPE_CHECKING:
+    from switchbot_client.api import SwitchBotAPIClient
+
+
+@dataclass()
+class SwitchBotScene:
+    client: SwitchBotAPIClient
+    scene_id: str
+    scene_name: str
+
+    def __post_init__(self):
+        if self.client is None:
+            raise TypeError
+        if self.scene_id is None:
+            raise TypeError
+
+    def execute(self) -> SwitchBotCommandResult:
+        response = self.client.scenes_execute(self.scene_id)
+        return SwitchBotCommandResult(response.status_code, response.message, response.body)
+
+    def __repr__(self):
+        data = {
+            "scene_id": self.scene_id,
+            "scene_name": self.scene_name,
+        }
+        return self.__class__.__qualname__ + f"({data})"

--- a/switchbot_client/types.py
+++ b/switchbot_client/types.py
@@ -1,16 +1,16 @@
 from typing_extensions import TypedDict
 
 
-class APIPhysicalDeviceObject(TypedDict):
+class APIDeviceObject(TypedDict):
     deviceId: str
     deviceName: str
+    hubDeviceId: str
+
+
+class APIPhysicalDeviceObject(APIDeviceObject):
     deviceType: str
     enableCloudService: bool
-    hubDeviceId: str
 
 
-class APIRemoteDeviceObject(TypedDict):
-    deviceId: str
-    deviceName: str
+class APIRemoteDeviceObject(APIDeviceObject):
     remoteType: str
-    hubDeviceId: str

--- a/switchbot_client/types.py
+++ b/switchbot_client/types.py
@@ -1,0 +1,16 @@
+from typing_extensions import TypedDict
+
+
+class APIPhysicalDeviceObject(TypedDict):
+    deviceId: str
+    deviceName: str
+    deviceType: str
+    enableCloudService: bool
+    hubDeviceId: str
+
+
+class APIRemoteDeviceObject(TypedDict):
+    deviceId: str
+    deviceName: str
+    remoteType: str
+    hubDeviceId: str

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,6 +5,14 @@ import requests
 
 from switchbot_client.api import SwitchBotAPIClient
 from switchbot_client.constants import AppConstants
+from switchbot_client.devices import (
+    AirConditioner,
+    HubMini,
+    Light,
+    Meter,
+    SwitchBotPhysicalDevice,
+    SwitchBotRemoteDevice,
+)
 
 
 @patch.object(SwitchBotAPIClient, "_load_config")
@@ -28,6 +36,14 @@ def test_init_by_config_file(patch_path_exists, mocker):
     patch_path_exists.return_value = True
     sut = SwitchBotAPIClient()
     m.assert_called_with(sut.config_file_path(), encoding="utf-8")
+
+
+@patch("os.path.exists")
+def test_init_by_another_config_file(patch_path_exists, mocker):
+    m = mocker.patch("builtins.open", mocker.mock_open(read_data="token: foo"))
+    patch_path_exists.return_value = True
+    sut = SwitchBotAPIClient(config_file_path="~/.config/switch-bot-client/another-config.yml")
+    m.assert_called_with("~/.config/switch-bot-client/another-config.yml", encoding="utf-8")
 
 
 @patch("os.path.exists")
@@ -60,21 +76,81 @@ def test_init_with_domain(patch_load_config):
     assert sut.api_host_domain == "https://new-api.example.com"
 
 
-def test_devices_status(monkeypatch):
+def test_devices(monkeypatch):
+    expected = {
+        "statusCode": 100,
+        "message": "success",
+        "body": {
+            "deviceList": [
+                {
+                    "deviceId": "ABCDEFG",
+                    "deviceName": "Meter 0A",
+                    "deviceType": "Meter",
+                    "enableCloudService": True,
+                    "hubDeviceId": "ABCDE",
+                },
+                {
+                    "deviceId": "ABCDE",
+                    "deviceName": "Hub Mini 0",
+                    "deviceType": "Hub Mini",
+                    "hubDeviceId": "ABCDE",
+                },
+            ],
+            "infraredRemoteList": [
+                {
+                    "deviceId": "12345",
+                    "deviceName": "My Light",
+                    "remoteType": "Light",
+                    "hubDeviceId": "ABCDE",
+                },
+                {
+                    "deviceId": "12345",
+                    "deviceName": "My Air Conditioner",
+                    "remoteType": "Air Conditioner",
+                    "hubDeviceId": "ABCDE",
+                },
+            ],
+        },
+    }
+
     class MockResponse:
         @staticmethod
         def json():
-            return {
-                "statusCode": 100,
-                "message": "success",
-                "body": {
-                    "deviceId": "ABCDE",
-                    "deviceType": "Meter",
-                    "hubDeviceId": "ABCDE",
-                    "humidity": 50,
-                    "temperature": 25.0,
-                },
-            }
+            return expected
+
+    def mock_get(*args, **kwargs):
+        return MockResponse()
+
+    def dummy_method(self):
+        pass
+
+    monkeypatch.setattr(SwitchBotPhysicalDevice, "_check_device_type", dummy_method)
+    monkeypatch.setattr(SwitchBotRemoteDevice, "_check_remote_type", dummy_method)
+    monkeypatch.setattr(requests, "get", mock_get)
+    client = SwitchBotAPIClient("token")
+    sut = client.devices()
+    assert sut.status_code == expected.get("statusCode")
+    assert sut.message == expected.get("message")
+    assert sut.body == expected.get("body")
+
+
+def test_devices_status(monkeypatch):
+    expected = {
+        "statusCode": 100,
+        "message": "success",
+        "body": {
+            "deviceId": "device_foo",
+            "deviceType": "Meter",
+            "hubDeviceId": "ABCDE",
+            "humidity": 50,
+            "temperature": 25.0,
+        },
+    }
+
+    class MockResponse:
+        @staticmethod
+        def json():
+            return expected
 
     def mock_get(*args, **kwargs):
         assert kwargs["headers"]["user-agent"] == f"switchbot-client/{AppConstants.VERSION}"
@@ -83,3 +159,6 @@ def test_devices_status(monkeypatch):
     monkeypatch.setattr(requests, "get", mock_get)
     client = SwitchBotAPIClient("token")
     sut = client.devices_status("device_foo")
+    assert sut.status_code == expected.get("statusCode")
+    assert sut.message == expected.get("message")
+    assert sut.body == expected.get("body")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,83 @@
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from switchbot_client.api import SwitchBotAPIClient
+
+
+@patch.object(SwitchBotAPIClient, "_load_config")
+def test_init_no_token(patch_load_config):
+    patch_load_config.return_value = None
+    with pytest.raises(RuntimeError):
+        SwitchBotAPIClient()
+
+
+@patch.object(SwitchBotAPIClient, "_load_config")
+def test_init_by_env(patch_load_config, monkeypatch):
+    patch_load_config.return_value = None
+    monkeypatch.setenv("SWITCHBOT_OPEN_TOKEN", "abcdefg")
+    sut = SwitchBotAPIClient()
+    assert sut.token == "abcdefg"
+
+
+@patch("os.path.exists")
+def test_init_by_config_file(patch_path_exists, mocker):
+    m = mocker.patch("builtins.open", mocker.mock_open(read_data="token: foo"))
+    patch_path_exists.return_value = True
+    sut = SwitchBotAPIClient()
+    m.assert_called_with(sut.config_file_path(), encoding="utf-8")
+
+
+@patch("os.path.exists")
+def test_init_by_config_file_no_token(patch_path_exists, mocker):
+    m = mocker.patch("builtins.open", mocker.mock_open(read_data="not_token: foo"))
+    patch_path_exists.return_value = True
+    with pytest.raises(RuntimeError):
+        SwitchBotAPIClient()
+
+
+@patch("os.path.exists")
+def test_init_by_config_file_no_file(patch_path_exists):
+    patch_path_exists.return_value = False
+    with pytest.raises(RuntimeError):
+        SwitchBotAPIClient()
+
+
+@patch.object(SwitchBotAPIClient, "_load_config")
+def test_init_by_args(patch_load_config):
+    patch_load_config.return_value = None
+    sut = SwitchBotAPIClient("123456")
+    assert sut.token == "123456"
+
+
+@patch.object(SwitchBotAPIClient, "_load_config")
+def test_init_with_domain(patch_load_config):
+    patch_load_config.return_value = None
+    sut = SwitchBotAPIClient(token="foobar", api_host_domain="https://new-api.example.com")
+    assert sut.token == "foobar"
+    assert sut.api_host_domain == "https://new-api.example.com"
+
+
+def test_devices_status(monkeypatch):
+    class MockResponse:
+        @staticmethod
+        def json():
+            return {
+                "statusCode": 100,
+                "message": "success",
+                "body": {
+                    "deviceId": "ABCDE",
+                    "deviceType": "Meter",
+                    "hubDeviceId": "ABCDE",
+                    "humidity": 50,
+                    "temperature": 25.0,
+                },
+            }
+
+    def mock_get(*args, **kwargs):
+        return MockResponse()
+
+    monkeypatch.setattr(requests, "get", mock_get)
+    client = SwitchBotAPIClient("token")
+    sut = client.devices_status("device_foo")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,6 +4,7 @@ import pytest
 import requests
 
 from switchbot_client.api import SwitchBotAPIClient
+from switchbot_client.constants import AppConstants
 
 
 @patch.object(SwitchBotAPIClient, "_load_config")
@@ -76,6 +77,7 @@ def test_devices_status(monkeypatch):
             }
 
     def mock_get(*args, **kwargs):
+        assert kwargs["headers"]["user-agent"] == f"switchbot-client/{AppConstants.VERSION}"
         return MockResponse()
 
     monkeypatch.setattr(requests, "get", mock_get)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,14 +5,7 @@ import requests
 
 from switchbot_client.api import SwitchBotAPIClient
 from switchbot_client.constants import AppConstants
-from switchbot_client.devices import (
-    AirConditioner,
-    HubMini,
-    Light,
-    Meter,
-    SwitchBotPhysicalDevice,
-    SwitchBotRemoteDevice,
-)
+from switchbot_client.devices import SwitchBotPhysicalDevice, SwitchBotRemoteDevice
 
 
 @patch.object(SwitchBotAPIClient, "_load_config")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,63 +1,17 @@
-import pytest
 import requests
-from unittest.mock import patch
-from switchbot_client.client import SwitchBotAPIClient
+
+from switchbot_client.client import SwitchBotClient
+from switchbot_client.devices import (
+    AirConditioner,
+    HubMini,
+    Light,
+    Meter,
+    SwitchBotPhysicalDevice,
+    SwitchBotRemoteDevice,
+)
 
 
-@patch.object(SwitchBotAPIClient, "_load_config")
-def test_init_no_token(patch_load_config):
-    patch_load_config.return_value = None
-    with pytest.raises(RuntimeError):
-        SwitchBotAPIClient()
-
-
-@patch.object(SwitchBotAPIClient, "_load_config")
-def test_init_by_env(patch_load_config, monkeypatch):
-    patch_load_config.return_value = None
-    monkeypatch.setenv("SWITCHBOT_OPEN_TOKEN", "abcdefg")
-    sut = SwitchBotAPIClient()
-    assert sut.token == "abcdefg"
-
-
-@patch("os.path.exists")
-def test_init_by_config_file(patch_path_exists, mocker):
-    m = mocker.patch("builtins.open", mocker.mock_open(read_data="token: foo"))
-    patch_path_exists.return_value = True
-    sut = SwitchBotAPIClient()
-    m.assert_called_with(sut.config_file_path(), encoding="utf-8")
-
-
-@patch("os.path.exists")
-def test_init_by_config_file_no_token(patch_path_exists, mocker):
-    m = mocker.patch("builtins.open", mocker.mock_open(read_data="not_token: foo"))
-    patch_path_exists.return_value = True
-    with pytest.raises(RuntimeError):
-        SwitchBotAPIClient()
-
-
-@patch("os.path.exists")
-def test_init_by_config_file_no_file(patch_path_exists):
-    patch_path_exists.return_value = False
-    with pytest.raises(RuntimeError):
-        SwitchBotAPIClient()
-
-
-@patch.object(SwitchBotAPIClient, "_load_config")
-def test_init_by_args(patch_load_config):
-    patch_load_config.return_value = None
-    sut = SwitchBotAPIClient("123456")
-    assert sut.token == "123456"
-
-
-@patch.object(SwitchBotAPIClient, "_load_config")
-def test_init_with_domain(patch_load_config):
-    patch_load_config.return_value = None
-    sut = SwitchBotAPIClient(token="foobar", api_host_domain="https://new-api.example.com")
-    assert sut.token == "foobar"
-    assert sut.api_host_domain == "https://new-api.example.com"
-
-
-def test_devices_status(monkeypatch):
+def test_devices(monkeypatch):
     class MockResponse:
         @staticmethod
         def json():
@@ -65,17 +19,52 @@ def test_devices_status(monkeypatch):
                 "statusCode": 100,
                 "message": "success",
                 "body": {
-                    "deviceId": "ABCDE",
-                    "deviceType": "Meter",
-                    "hubDeviceId": "ABCDE",
-                    "humidity": 50,
-                    "temperature": 25.0,
+                    "deviceList": [
+                        {
+                            "deviceId": "ABCDEFG",
+                            "deviceName": "Meter 0A",
+                            "deviceType": "Meter",
+                            "enableCloudService": True,
+                            "hubDeviceId": "ABCDE",
+                        },
+                        {
+                            "deviceId": "ABCDE",
+                            "deviceName": "Hub Mini 0",
+                            "deviceType": "Hub Mini",
+                            "hubDeviceId": "ABCDE",
+                        },
+                    ],
+                    "infraredRemoteList": [
+                        {
+                            "deviceId": "12345",
+                            "deviceName": "My Light",
+                            "remoteType": "Light",
+                            "hubDeviceId": "ABCDE",
+                        },
+                        {
+                            "deviceId": "12345",
+                            "deviceName": "My Air Conditioner",
+                            "remoteType": "Air Conditioner",
+                            "hubDeviceId": "ABCDE",
+                        },
+                    ],
                 },
             }
 
     def mock_get(*args, **kwargs):
         return MockResponse()
 
+    def dummy_method(self):
+        pass
+
+    monkeypatch.setattr(SwitchBotPhysicalDevice, "_check_device_type", dummy_method)
+    monkeypatch.setattr(SwitchBotRemoteDevice, "_check_remote_type", dummy_method)
     monkeypatch.setattr(requests, "get", mock_get)
-    client = SwitchBotAPIClient("token")
-    sut = client.devices_status("device_foo")
+    client = SwitchBotClient("token")
+    sut = client.devices()
+    assert sorted([type(e) for e in sut], key=lambda e: e.__name__) == [
+        AirConditioner,
+        HubMini,
+        Light,
+        Meter,
+    ]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -54,7 +54,7 @@ def test_devices(monkeypatch):
     def mock_get(*args, **kwargs):
         return MockResponse()
 
-    def dummy_method(self):
+    def dummy_method(self, *args):
         pass
 
     monkeypatch.setattr(SwitchBotPhysicalDevice, "_check_device_type", dummy_method)

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -2,65 +2,39 @@ import inspect
 
 import pytest
 
-from switchbot_client import ControlCommand, DeviceType, RemoteType
+from switchbot_client import ControlCommand
 from switchbot_client.api import SwitchBotAPIClient, SwitchBotAPIResponse
-from switchbot_client.devices import (
-    Bot,
-    Light,
-    SwitchBotPhysicalDevice,
-    SwitchBotRemoteDevice,
-    physical,
-    remote,
-)
-
-
-def test_all_devices_defined(monkeypatch):
-    client = SwitchBotAPIClient("token")
-
-    def dummy_method(self):
-        pass
-
-    monkeypatch.setattr(SwitchBotPhysicalDevice, "_check_device_type", dummy_method)
-    monkeypatch.setattr(SwitchBotRemoteDevice, "_check_remote_type", dummy_method)
-
-    physical_types = [getattr(DeviceType, a) for a in dir(DeviceType()) if not a.startswith("_")]
-    defined_physicals = [
-        a[1]
-        for a in inspect.getmembers(physical, inspect.isclass)
-        if issubclass(a[1], SwitchBotPhysicalDevice) and a[0] != "SwitchBotPhysicalDevice"
-    ]
-    defined_physicals_types = []
-    for cls in defined_physicals:
-        t = cls(client, "dummy").device_type
-        assert t in physical_types
-        defined_physicals_types.append(t)
-    for t in physical_types:
-        assert t in defined_physicals_types
-
-    remote_types = [getattr(RemoteType, a) for a in dir(RemoteType()) if not a.startswith("_")]
-    defined_remotes = [
-        a[1]
-        for a in inspect.getmembers(remote, inspect.isclass)
-        if issubclass(a[1], SwitchBotRemoteDevice) and a[0] != "SwitchBotRemoteDevice"
-    ]
-    defined_remotes_types = []
-    for cls in defined_remotes:
-        t = cls(client, "dummy").device_type
-        assert t in remote_types
-        defined_remotes_types.append(t)
-    for t in remote_types:
-        assert t in defined_remotes_types
+from switchbot_client.devices import Bot, Light
+from switchbot_client.types import APIPhysicalDeviceObject
 
 
 def test_init_no_client():
+    device = APIPhysicalDeviceObject(
+        deviceId="",
+        deviceName="",
+        hubDeviceId="",
+        deviceType="",
+        enableCloudService=True,
+    )
     with pytest.raises(TypeError):
-        Bot(client=None, device_id="device_id")
+        Bot(client=None, device=device)
 
 
-def test_init_no_device_id():
+def test_init_no_device():
     with pytest.raises(TypeError):
         client = SwitchBotAPIClient("token")
         Bot(client, None)
+
+
+def test_create_no_client():
+    with pytest.raises(TypeError):
+        Bot.create_by_id(client=None, device_id="id")
+
+
+def test_create_no_device_id():
+    with pytest.raises(TypeError):
+        client = SwitchBotAPIClient("token")
+        Bot.create_by_id(client=client, device_id=None)
 
 
 def test_illegal_device_type(monkeypatch):
@@ -69,19 +43,23 @@ def test_illegal_device_type(monkeypatch):
             status_code=100,
             message="success",
             body={
-                "deviceId": "ABCDE",
-                "deviceType": "Meter",
-                "hubDeviceId": "ABCDE",
-                "humidity": 50,
-                "temperature": 25.0,
+                "deviceList": [
+                    {
+                        "deviceId": "ABCDE",
+                        "deviceType": "Meter",
+                        "hubDeviceId": "ABCDE",
+                        "humidity": 50,
+                        "temperature": 25.0,
+                    }
+                ]
             },
         )
 
-    monkeypatch.setattr(SwitchBotAPIClient, "devices_status", mock_get)
+    monkeypatch.setattr(SwitchBotAPIClient, "devices", mock_get)
 
     with pytest.raises(RuntimeError):
         client = SwitchBotAPIClient("token")
-        Bot(client, "device_id")
+        Bot.create_by_id(client, "device_id")
 
 
 def test_virtual_infrared_no_device(monkeypatch):
@@ -96,7 +74,7 @@ def test_virtual_infrared_no_device(monkeypatch):
 
     with pytest.raises(RuntimeError):
         client = SwitchBotAPIClient("token")
-        Light(client, "00-202001010000-12345678")
+        Light.create_by_id(client, "00-202001010000-12345678")
 
 
 def test_virtual_infrared_illegal_device_type(monkeypatch):
@@ -120,7 +98,7 @@ def test_virtual_infrared_illegal_device_type(monkeypatch):
 
     with pytest.raises(RuntimeError):
         client = SwitchBotAPIClient("token")
-        Light(client, "00-202001010000-12345678")
+        Light.create_by_id(client, "00-202001010000-12345678")
 
 
 def test_light(monkeypatch):
@@ -163,6 +141,6 @@ def test_light(monkeypatch):
     monkeypatch.setattr(SwitchBotAPIClient, "devices", mock_devices)
     monkeypatch.setattr(SwitchBotAPIClient, "devices_commands", mock_devices_commands)
 
-    device = Light(client, "00-202001010000-12345678")
+    device = Light.create_by_id(client, "00-202001010000-12345678")
     result = device.turn_on()
     assert result.message == "success"

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -1,9 +1,17 @@
-import pytest
 import inspect
+
+import pytest
+
 from switchbot_client import ControlCommand, DeviceType, RemoteType
-from switchbot_client.client import SwitchBotAPIClient, SwitchBotAPIResponse
-from switchbot_client.devices import Bot, Light, SwitchBotDevice, SwitchBotRemoteDevice
-from switchbot_client.devices import remote, physical
+from switchbot_client.api import SwitchBotAPIClient, SwitchBotAPIResponse
+from switchbot_client.devices import (
+    Bot,
+    Light,
+    SwitchBotPhysicalDevice,
+    SwitchBotRemoteDevice,
+    physical,
+    remote,
+)
 
 
 def test_all_devices_defined(monkeypatch):
@@ -12,14 +20,14 @@ def test_all_devices_defined(monkeypatch):
     def dummy_method(self):
         pass
 
-    monkeypatch.setattr(SwitchBotDevice, "_check_device_type", dummy_method)
+    monkeypatch.setattr(SwitchBotPhysicalDevice, "_check_device_type", dummy_method)
     monkeypatch.setattr(SwitchBotRemoteDevice, "_check_remote_type", dummy_method)
 
     physical_types = [getattr(DeviceType, a) for a in dir(DeviceType()) if not a.startswith("_")]
     defined_physicals = [
         a[1]
         for a in inspect.getmembers(physical, inspect.isclass)
-        if issubclass(a[1], SwitchBotDevice) and a[0] != "SwitchBotDevice"
+        if issubclass(a[1], SwitchBotPhysicalDevice) and a[0] != "SwitchBotPhysicalDevice"
     ]
     defined_physicals_types = []
     for cls in defined_physicals:

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -1,5 +1,3 @@
-import inspect
-
 import pytest
 
 from switchbot_client import ControlCommand

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ commands = poetry run flake8 switchbot_client
 
 [flake8]
 max-line-length = 100
+ignore = E203,W503
 
 [testenv:isort]
 commands = poetry run isort switchbot_client tests --check --diff

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     black
     pylint
     flake8
+    isort
     mypy
 
 [testenv]
@@ -27,6 +28,9 @@ commands = poetry run flake8 switchbot_client
 
 [flake8]
 max-line-length = 100
+
+[testenv:isort]
+commands = poetry run isort switchbot_client tests --check --diff
 
 [testenv:mypy]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,34 @@
+[tox]
+isolated_build = True
+envlist =
+    py3
+    black
+    pylint
+    flake8
+    mypy
+
+[testenv]
+whitelist_externals = poetry
+skip_install = true
+basepython = python3
+commands = poetry install
+
+[testenv:py3]
+commands = poetry run pytest tests
+
+[testenv:black]
+commands = poetry run black switchbot_client tests --check --diff
+
+[testenv:pylint]
+commands = poetry run pylint switchbot_client
+
+[testenv:flake8]
+commands = poetry run flake8 switchbot_client
+
+[flake8]
+max-line-length = 100
+
+[testenv:mypy]
+commands =
+    poetry run mypy --install-types --non-interactive switchbot_client
+    poetry run mypy switchbot_client


### PR DESCRIPTION
## PRs

- #16
- #17 
- #18 
- #19 
- #20 
- #21

## Changes

- API Interface Change
  - Use object interface as the main one
  - It is recommended to use SwitchBotClient instead of SwitchBotAPIClient
- Add new devices(Motion Sensor, Contact Sensor, Color Bulb, Remote)
- Use `switchbot-client/{version}` as the user agent when requesting the SwitchBot API
- Remove Python 3.6.x support and add Python 3.10.x support