### PR TITLE
Fix the behavior when lackWater column is missing

### DIFF
--- a/switchbot_client/devices/physical.py
+++ b/switchbot_client/devices/physical.py
@@ -621,7 +621,7 @@ class Humidifier(SwitchBotPhysicalDevice):
             is_auto=status.raw_data["auto"],
             is_child_lock=status.raw_data["childLock"],
             is_muted=not status.raw_data["sound"],
-            is_lack_water=status.raw_data["lackWater"],
+            is_lack_water=status.raw_data["lackWater"] if "lackWater" in status.raw_data else False,
         )
 
     def power(self) -> str:


### PR DESCRIPTION
- The API documentation specifies the lackWater column, but in practice it seems to be missing in some cases
- Missing values are assumed to mean False, but this is not confirmed
https://github.com/OpenWonderLabs/SwitchBotAPI#get-device-status
