### PR TITLE
Add new device types and avoid error when undefined devices detected

### DIFF
--- a/switchbot_client/client.py
+++ b/switchbot_client/client.py
@@ -23,7 +23,12 @@ class SwitchBotClient:
         response = self.api_client.devices().body
         devices = response["deviceList"]
         devices.extend(response["infraredRemoteList"])
-        return [SwitchBotDeviceFactory.create(self, d) for d in devices]
+        items = []
+        for device in devices:
+            model = SwitchBotDeviceFactory.create(self, device)
+            if model:
+                items.append(model)
+        return items
 
     def device(self, device_id: str) -> Optional[SwitchBotDevice]:
         filtered = [d for d in self.devices() if d.device_id == device_id]

--- a/switchbot_client/devices/factory.py
+++ b/switchbot_client/devices/factory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Union
+import logging
+from typing import TYPE_CHECKING, Optional, Union
 
 from .physical import SwitchBotPhysicalDevice
 from .remote import SwitchBotRemoteDevice
@@ -16,9 +17,10 @@ class SwitchBotDeviceFactory:
     def create(
         client: SwitchBotClient,
         api_object: Union[APIPhysicalDeviceObject, APIRemoteDeviceObject],
-    ) -> SwitchBotDevice:
+    ) -> Optional[SwitchBotDevice]:
         if "deviceType" in api_object:
             return SwitchBotPhysicalDevice.create_by_api_object(client, api_object)  # type: ignore
         if "remoteType" in api_object:
             return SwitchBotRemoteDevice.create_by_api_object(client, api_object)  # type: ignore
-        raise TypeError(f"invalid device object: {api_object}")
+        logging.warning("invalid device object: %s", api_object)
+        return None

--- a/switchbot_client/devices/physical.py
+++ b/switchbot_client/devices/physical.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import logging
 from abc import abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from switchbot_client.devices.status import (
     BotDeviceStatus,
@@ -42,7 +43,7 @@ class SwitchBotPhysicalDevice(SwitchBotDevice):
     @staticmethod
     def create_by_api_object(  # noqa
         client: SwitchBotClient, device: APIPhysicalDeviceObject
-    ) -> SwitchBotPhysicalDevice:
+    ) -> Optional[SwitchBotPhysicalDevice]:
         # pylint: disable=too-many-branches,too-many-return-statements
         device_type = device["deviceType"]
         if device_type == DeviceType.HUB:
@@ -77,18 +78,29 @@ class SwitchBotPhysicalDevice(SwitchBotDevice):
             return SmartFan(client, device)
         if device_type == DeviceType.STRIP_LIGHT:
             return StripLight(client, device)
+        if device_type == DeviceType.CEILING_LIGHT:
+            pass
+        if device_type == DeviceType.CEILING_LIGHT_PRO:
+            pass
         if device_type == DeviceType.INDOOR_CAM:
             return IndoorCam(client, device)
+        if device_type == DeviceType.PAN_TILT_CAM:
+            pass
         if device_type == DeviceType.REMOTE:
             return Remote(client, device)
         if device_type == DeviceType.LOCK:
             return Lock(client, device)
+        if device_type == DeviceType.KEYPAD:
+            pass
+        if device_type == DeviceType.KEYPAD_TOUCH:
+            pass
         if device_type == DeviceType.ROBOT_VACUUM_CLEANER_S1:
             return RobotVacuumCleanerS1(client, device)
         if device_type == DeviceType.ROBOT_VACUUM_CLEANER_S1_PLUS:
             return RobotVacuumCleanerS1Plus(client, device)
 
-        raise TypeError(f"invalid physical device object: {device}")
+        logging.warning("invalid physical device object %s", device)
+        return None
 
     @staticmethod
     def get_device_by_id(client: SwitchBotClient, device_id: str) -> APIPhysicalDeviceObject:

--- a/switchbot_client/devices/remote.py
+++ b/switchbot_client/devices/remote.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Generic, Optional, TypeVar
 
 from switchbot_client.enums import ControlCommand, RemoteType
@@ -49,7 +50,7 @@ class SwitchBotRemoteDevice(SwitchBotDevice, Generic[AnyRemoteDeviceStatus]):
     @staticmethod
     def create_by_api_object(  # noqa
         client: SwitchBotClient, device: APIRemoteDeviceObject
-    ) -> SwitchBotRemoteDevice:
+    ) -> Optional[SwitchBotRemoteDevice]:
         # pylint: disable=too-many-branches,too-many-return-statements
         remote_type = device["remoteType"]
         if remote_type == RemoteType.AIR_CONDITIONER:
@@ -81,7 +82,8 @@ class SwitchBotRemoteDevice(SwitchBotDevice, Generic[AnyRemoteDeviceStatus]):
         if remote_type == RemoteType.OTHERS:
             return Others(client, device)
 
-        raise TypeError(f"invalid physical device object: {device}")
+        logging.warning("invalid remote device object: %s", device)
+        return None
 
     @staticmethod
     def get_device_by_id(client: SwitchBotClient, device_id: str) -> APIRemoteDeviceObject:

--- a/switchbot_client/enums.py
+++ b/switchbot_client/enums.py
@@ -15,9 +15,14 @@ class DeviceType:
     HUMIDIFIER = "Humidifier"
     SMART_FAN = "Smart Fan"
     STRIP_LIGHT = "Strip Light"
+    CEILING_LIGHT = "Ceiling Light"
+    CEILING_LIGHT_PRO = "Ceiling Light Pro"
     INDOOR_CAM = "Indoor Cam"
-    REMOTE = "Remote"  # undocumented in official api reference?
-    LOCK = "Lock"
+    PAN_TILT_CAM = "Pan/Tilt Cam"
+    REMOTE = "Remote"
+    LOCK = "Smart Lock"
+    KEYPAD = "Keypad"
+    KEYPAD_TOUCH = "Keypad Touch"
     ROBOT_VACUUM_CLEANER_S1_PLUS = "Robot Vacuum Cleaner S1"
     ROBOT_VACUUM_CLEANER_S1 = "Robot Vacuum Cleaner S1 Plus"
 


### PR DESCRIPTION
- New device types added
- When a device not yet defined in this library is detected, only a warning message is generated and no error occurs